### PR TITLE
[FEATURE] 세금계산서 검증 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,9 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+
+	// configuration-processor
+	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,10 @@ dependencies {
 
 	// OpenFeign
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+	// codef
+	implementation 'io.codef.api:easycodef-java:1.0.6'
+	implementation 'org.json:json:20210307'
 }
 
 tasks.named('test') {

--- a/src/main/java/SeoulMilk1_BE/auth/util/RSAUtil.java
+++ b/src/main/java/SeoulMilk1_BE/auth/util/RSAUtil.java
@@ -1,0 +1,39 @@
+package SeoulMilk1_BE.auth.util;
+
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+
+@Component
+public class RSAUtil {
+    /**
+     * RSA 암호화
+     **/
+    public String encryptRSA(String password, String publicKey) throws Exception{
+        PublicKey publicKeyFromString = getPublicKeyFromString(publicKey);
+
+        // PEM 형식의 공개키 문자열을 Base64로 디코딩
+        // RSA 암호화 수행
+        Cipher cipher = Cipher.getInstance("RSA");
+        cipher.init(Cipher.ENCRYPT_MODE, publicKeyFromString);  // 암호화 모드로 초기화
+
+        byte[] encryptedPassword = cipher.doFinal(password.getBytes(StandardCharsets.UTF_8)); // 비밀번호 암호화
+
+        // Base64로 인코딩하여 출력 (문자열로 안전하게 전달)
+        return Base64.getEncoder().encodeToString(encryptedPassword);
+    }
+
+    private PublicKey getPublicKeyFromString(String publicKey) throws Exception {
+        byte[] decodedKey = Base64.getDecoder().decode(publicKey);
+
+        // X.509 포맷으로 공개키 복원
+        X509EncodedKeySpec keySpec = new X509EncodedKeySpec(decodedKey);
+        KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+        return keyFactory.generatePublic(keySpec);
+    }
+}

--- a/src/main/java/SeoulMilk1_BE/auth/util/RSAUtil.java
+++ b/src/main/java/SeoulMilk1_BE/auth/util/RSAUtil.java
@@ -1,5 +1,7 @@
 package SeoulMilk1_BE.auth.util;
 
+import SeoulMilk1_BE.global.apiPayload.code.status.ErrorStatus;
+import SeoulMilk1_BE.global.apiPayload.exception.GeneralException;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.Cipher;
@@ -14,18 +16,22 @@ public class RSAUtil {
     /**
      * RSA 암호화
      **/
-    public String encryptRSA(String password, String publicKey) throws Exception{
-        PublicKey publicKeyFromString = getPublicKeyFromString(publicKey);
+    public String encryptRSA(String password, String publicKey){
+        try {
+            PublicKey publicKeyFromString = getPublicKeyFromString(publicKey);
 
-        // PEM 형식의 공개키 문자열을 Base64로 디코딩
-        // RSA 암호화 수행
-        Cipher cipher = Cipher.getInstance("RSA");
-        cipher.init(Cipher.ENCRYPT_MODE, publicKeyFromString);  // 암호화 모드로 초기화
+            // PEM 형식의 공개키 문자열을 Base64로 디코딩
+            // RSA 암호화 수행
+            Cipher cipher = Cipher.getInstance("RSA");
+            cipher.init(Cipher.ENCRYPT_MODE, publicKeyFromString);  // 암호화 모드로 초기화
 
-        byte[] encryptedPassword = cipher.doFinal(password.getBytes(StandardCharsets.UTF_8)); // 비밀번호 암호화
+            byte[] encryptedPassword = cipher.doFinal(password.getBytes(StandardCharsets.UTF_8)); // 비밀번호 암호화
 
-        // Base64로 인코딩하여 출력 (문자열로 안전하게 전달)
-        return Base64.getEncoder().encodeToString(encryptedPassword);
+            // Base64로 인코딩하여 출력 (문자열로 안전하게 전달)
+            return Base64.getEncoder().encodeToString(encryptedPassword);
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus.ENCRYPTION_FAILED);
+        }
     }
 
     private PublicKey getPublicKeyFromString(String publicKey) throws Exception {

--- a/src/main/java/SeoulMilk1_BE/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/SeoulMilk1_BE/global/apiPayload/code/status/ErrorStatus.java
@@ -38,6 +38,7 @@ public enum ErrorStatus implements BaseErrorCode {
     IPTYPECODE_NOT_FOUND(HttpStatus.NOT_FOUND, "TAX403", "해당 구분 코드를 찾을 수 없습니다."),
     TAX_NOT_FOUND(HttpStatus.NOT_FOUND, "TAX404", "해당 세금 계산서를 찾을 수 없습니다."),
     OCR_LOAD_ERROR(HttpStatus.BAD_REQUEST, "TAX405", "OCR 로드 중 에러가 발생했습니다."),
+    ENCRYPTION_FAILED(HttpStatus.BAD_REQUEST, "TAX406", "RSA 암호화 중 에러가 발생했습니다."),
 
     // 게시글 관련 에러
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST400", "해당 게시글을 찾을 수 없습니다."),

--- a/src/main/java/SeoulMilk1_BE/nts_tax/controller/NtsTaxController.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/controller/NtsTaxController.java
@@ -33,6 +33,14 @@ public class NtsTaxController {
         return ApiResponse.onSuccess(ocrService.callOcrApi(userId, file));
     }
 
+    @Operation(summary = "세금명세서 검증", description = "검증할 세금계산서 id를 PathVariable로 넘겨주세요!!")
+    @PostMapping(path = "/validate/{ntsTaxId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<String> validateNtsTax(
+            @PathVariable("ntsTaxId") Long ntsTaxId
+    ) {
+        return ApiResponse.onSuccess(ntsTaxService.validateNtsTax(ntsTaxId));
+    }
+
     @Operation(summary = "세금명세서 수정", description = "OCR에서 추출한 텍스트를 수정")
     @PutMapping("/{ntsTaxId}")
     public ApiResponse<String> updateNtsTax(

--- a/src/main/java/SeoulMilk1_BE/nts_tax/controller/NtsTaxController.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/controller/NtsTaxController.java
@@ -34,7 +34,7 @@ public class NtsTaxController {
     }
 
     @Operation(summary = "세금명세서 검증", description = "검증할 세금계산서 id를 PathVariable로 넘겨주세요!!")
-    @PostMapping(path = "/validate/{ntsTaxId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping(path = "/validate/{ntsTaxId}")
     public ApiResponse<String> validateNtsTax(
             @PathVariable("ntsTaxId") Long ntsTaxId
     ) {

--- a/src/main/java/SeoulMilk1_BE/nts_tax/domain/NtsTax.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/domain/NtsTax.java
@@ -198,6 +198,9 @@ public class NtsTax extends BaseTimeEntity {
     @Column(name = "trans_date", length = 12)
     private String transDate;
 
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
     public static NtsTax toNtsTax(OcrApiResponse response, User user, String imageUrl) {
         return NtsTax.builder()
                 .issueId(formatInputData(getInferText(response, "승인번호")))
@@ -261,5 +264,19 @@ public class NtsTax extends BaseTimeEntity {
         }
 
         return name.split(" ")[0];
+    }
+
+    public void updateStatus(int status) {
+        switch (status) {
+            case 0:
+                this.status = Status.APPROVE;
+                break;
+            case 1:
+                this.status = Status.REFUSED;
+                break;
+            default:
+                this.status = Status.DONE;
+                break;
+        }
     }
 }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/domain/type/Status.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/domain/type/Status.java
@@ -1,0 +1,7 @@
+package SeoulMilk1_BE.nts_tax.domain.type;
+
+public enum Status {
+    APPROVE,
+    REFUSED,
+    DONE
+}

--- a/src/main/java/SeoulMilk1_BE/nts_tax/dto/request/CodefApiRequest.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/dto/request/CodefApiRequest.java
@@ -5,9 +5,9 @@ public record CodefApiRequest(
         String ipId,
         String issueId,
         String chargeTotal,
-        String transDate
+        String issueDate
 ) {
-    public static CodefApiRequest of(String suId, String ipIp, String issueId, Long chargeTotal, String transDate) {
-        return new CodefApiRequest(suId, ipIp, issueId, Long.toString(chargeTotal), transDate);
+    public static CodefApiRequest of(String suId, String ipIp, String issueId, Long chargeTotal, String issueDate) {
+        return new CodefApiRequest(suId, ipIp, issueId, Long.toString(chargeTotal), issueDate);
     }
 }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/dto/request/CodefApiRequest.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/dto/request/CodefApiRequest.java
@@ -1,0 +1,13 @@
+package SeoulMilk1_BE.nts_tax.dto.request;
+
+public record CodefApiRequest(
+        String suId,
+        String ipId,
+        String issueId,
+        String chargeTotal,
+        String transDate
+) {
+    public static CodefApiRequest of(String suId, String ipIp, String issueId, Long chargeTotal, String transDate) {
+        return new CodefApiRequest(suId, ipIp, issueId, Long.toString(chargeTotal), transDate);
+    }
+}

--- a/src/main/java/SeoulMilk1_BE/nts_tax/dto/request/CodefApiRequest.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/dto/request/CodefApiRequest.java
@@ -1,7 +1,9 @@
 package SeoulMilk1_BE.nts_tax.dto.request;
 
 import SeoulMilk1_BE.nts_tax.domain.NtsTax;
+import lombok.Builder;
 
+@Builder
 public record CodefApiRequest(
         String suId,
         String ipId,
@@ -10,7 +12,13 @@ public record CodefApiRequest(
         String issueDate
 ) {
     public static CodefApiRequest from(NtsTax ntsTax) {
-        return new CodefApiRequest(ntsTax.getSuId(), ntsTax.getIpId(), ntsTax.getIssueId(), Long.toString(ntsTax.getChargeTotal()), ntsTax.getIssueDate());
+        return CodefApiRequest.builder()
+                .suId(ntsTax.getSuId())
+                .ipId(ntsTax.getIpId())
+                .issueId(ntsTax.getIssueId())
+                .chargeTotal(Long.toString(ntsTax.getChargeTotal()))
+                .issueDate(ntsTax.getIssueDate())
+                .build();
     }
 
 }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/dto/request/CodefApiRequest.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/dto/request/CodefApiRequest.java
@@ -1,5 +1,7 @@
 package SeoulMilk1_BE.nts_tax.dto.request;
 
+import SeoulMilk1_BE.nts_tax.domain.NtsTax;
+
 public record CodefApiRequest(
         String suId,
         String ipId,
@@ -7,7 +9,8 @@ public record CodefApiRequest(
         String chargeTotal,
         String issueDate
 ) {
-    public static CodefApiRequest of(String suId, String ipIp, String issueId, Long chargeTotal, String issueDate) {
-        return new CodefApiRequest(suId, ipIp, issueId, Long.toString(chargeTotal), issueDate);
+    public static CodefApiRequest from(NtsTax ntsTax) {
+        return new CodefApiRequest(ntsTax.getSuId(), ntsTax.getIpId(), ntsTax.getIssueId(), Long.toString(ntsTax.getChargeTotal()), ntsTax.getIssueDate());
     }
+
 }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/service/CodefService.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/service/CodefService.java
@@ -1,0 +1,225 @@
+package SeoulMilk1_BE.nts_tax.service;
+
+import SeoulMilk1_BE.auth.util.RSAUtil;
+import SeoulMilk1_BE.nts_tax.domain.NtsTax;
+import SeoulMilk1_BE.nts_tax.dto.request.CodefApiRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.codef.api.EasyCodefConstant;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.codec.binary.Base64;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+
+@Service
+@RequiredArgsConstructor
+public class CodefService extends EasyCodefConstant {
+    @Value("${codef.client-id}")
+    private String clientId;
+    @Value("${codef.client-secret}")
+    private String clientSecret;
+    @Value("${codef.client-pfx}")
+    private String certFile;
+    @Value("${codef.client-password}")
+    private String password;
+    @Value("${codef.client-publickey}")
+    private String publicKey;
+    private final RSAUtil rsaUtil;
+    private final NtsTaxService ntsTaxService;
+
+    private static final URL url;
+
+    /**
+     제3자 발급 사실 조회 OpenAPI URL 세팅
+     **/
+    static {
+        try {
+            url = new URL("https://development.codef.io/v1/kr/public/nt/third-party/tax-invoice-issue");
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public JsonNode validateNtsTax(Long id) {
+        NtsTax ntsTax = ntsTaxService.findById(id);
+        CodefApiRequest request = CodefApiRequest.of(ntsTax.getSuId(), ntsTax.getIpId(), ntsTax.getIssueId(), ntsTax.getChargeTotal(), ntsTax.getTransDate());
+
+        String accessToken = (String) publishToken().get("access_token");
+        String resultLv1 = getIssuedTaxInvoiceInfo(accessToken, request);
+        return decodeResult(resultLv1);
+    }
+
+    /**
+     * 결과 값 디코딩
+     **/
+    private JsonNode decodeResult(String result) {
+        try {
+            String decode = URLDecoder.decode(result, StandardCharsets.UTF_8);
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode jsonNode = mapper.readTree(decode);
+            return jsonNode;
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Access Token 발행
+     **/
+    private HashMap publishToken() {
+        BufferedReader br = null;
+        try {
+            // HTTP 요청을 위한 URL 오브젝트 생성
+            URL url = new URL(EasyCodefConstant.OAUTH_DOMAIN + EasyCodefConstant.GET_TOKEN);
+            String params = "grant_type=client_credentials&scope=read";    // Oauth2.0 사용자 자격증명 방식(client_credentials) 토큰 요청 설정
+
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+            con.setRequestMethod("POST");
+            con.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+
+            // 클라이언트아이디, 시크릿코드 Base64 인코딩
+            String auth = clientId + ":" + clientSecret;
+            byte[] authEncBytes = Base64.encodeBase64(auth.getBytes());
+            String authStringEnc = new String(authEncBytes);
+            String authHeader = "Basic " + authStringEnc;
+
+            con.setRequestProperty("Authorization", authHeader);
+            con.setDoInput(true);
+            con.setDoOutput(true);
+
+            // 리퀘스트 바디 전송
+            OutputStream os = con.getOutputStream();
+            os.write(params.getBytes());
+            os.flush();
+            os.close();
+
+            // 응답 코드 확인
+            int responseCode = con.getResponseCode();
+            if (responseCode == HttpURLConnection.HTTP_OK) {    // 정상 응답
+                br = new BufferedReader(new InputStreamReader(con.getInputStream()));
+            } else {     // 에러 발생
+                return null;
+            }
+
+            // 응답 바디 read
+            String inputLine;
+            StringBuffer responseStr = new StringBuffer();
+            while ((inputLine = br.readLine()) != null) {
+                responseStr.append(inputLine);
+            }
+            br.close();
+
+            // 응답결과 URL Decoding(UTF-8)
+            ObjectMapper mapper = new ObjectMapper();
+            HashMap<String, Object> tokenMap = mapper.readValue(URLDecoder.decode(responseStr.toString(), "UTF-8"), new TypeReference<HashMap<String, Object>>() {
+            });
+            return tokenMap;
+
+        } catch (Exception e) {
+            return null;
+        } finally {
+            if (br != null) {
+                try {
+                    br.close();
+                } catch (IOException e) {
+                }
+            }
+        }
+    }
+
+    /**
+     * 기본 요청 값 세팅
+     **/
+    private JSONObject setRequestJsonObject(CodefApiRequest request) throws Exception {
+        JSONObject jsonRequest = new JSONObject();
+        jsonRequest.put("organization", "0004");
+
+        // 사용자 관련
+        jsonRequest.put("loginType", "0");
+        jsonRequest.put("certType", "pfx");
+        jsonRequest.put("certFile", certFile);
+        jsonRequest.put("certPassword", rsaUtil.encryptRSA(password, publicKey));
+        jsonRequest.put("supplierRegNumber", request.suId());
+        jsonRequest.put("contractorRegNumber", request.ipId());
+        jsonRequest.put("approvalNo", request.issueId());
+        jsonRequest.put("reportingDate", request.transDate());
+        jsonRequest.put("supplyValue", request.chargeTotal());
+
+        return jsonRequest;
+    }
+
+    /**
+     * 요청 헤더 세팅
+     **/
+    private static HttpURLConnection getHttpURLConnection(String accessToken, URL url) throws IOException {
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        con.setRequestMethod("POST");
+        con.setRequestProperty("Content-Type", "application/json");
+        con.setRequestProperty("Authorization", "Bearer " + accessToken);
+        con.setDoOutput(true);
+        return con;
+    }
+
+    /**
+     * API 요청
+     **/
+    private String getIssuedTaxInvoiceInfo(String accessToken, CodefApiRequest request) {
+        BufferedReader br = null;
+        try {
+            HttpURLConnection con = getHttpURLConnection(accessToken, url);
+
+
+            JSONObject jsonRequest = setRequestJsonObject(request);
+
+            byte[] jsonData = jsonRequest.toString().getBytes(StandardCharsets.UTF_8);
+
+            try (OutputStream os = con.getOutputStream()) {
+                os.write(jsonData);
+            }
+
+            // 응답 코드 확인
+            int responseCode = con.getResponseCode();
+            if (responseCode == HttpURLConnection.HTTP_OK) { // 정상 응답
+                br = new BufferedReader(new InputStreamReader(con.getInputStream(), "utf-8"));
+            } else { // 오류 발생 시
+                br = new BufferedReader(new InputStreamReader(con.getErrorStream(), "utf-8"));
+            }
+
+            // 응답 데이터 읽기
+            StringBuilder response = new StringBuilder();
+            String inputLine;
+            while ((inputLine = br.readLine()) != null) {
+                response.append(inputLine);
+            }
+
+            return response.toString();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        } finally {
+            if (br != null) {
+                try {
+                    br.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/SeoulMilk1_BE/nts_tax/service/CodefService.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/service/CodefService.java
@@ -2,6 +2,7 @@ package SeoulMilk1_BE.nts_tax.service;
 
 import SeoulMilk1_BE.auth.util.RSAUtil;
 import SeoulMilk1_BE.nts_tax.dto.request.CodefApiRequest;
+import SeoulMilk1_BE.nts_tax.util.CodefConfigProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -10,7 +11,6 @@ import io.codef.api.EasyCodefConstant;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.codec.binary.Base64;
 import org.json.JSONObject;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
@@ -27,16 +27,7 @@ import java.util.HashMap;
 @Service
 @RequiredArgsConstructor
 public class CodefService extends EasyCodefConstant {
-    @Value("${codef.client-id}")
-    private String clientId;
-    @Value("${codef.client-secret}")
-    private String clientSecret;
-    @Value("${codef.client-pfx}")
-    private String certFile;
-    @Value("${codef.client-password}")
-    private String password;
-    @Value("${codef.client-publickey}")
-    private String publicKey;
+    private final CodefConfigProperties properties;
     private final RSAUtil rsaUtil;
 
     private static final URL url;
@@ -87,7 +78,7 @@ public class CodefService extends EasyCodefConstant {
             con.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
 
             // 클라이언트아이디, 시크릿코드 Base64 인코딩
-            String auth = clientId + ":" + clientSecret;
+            String auth = properties.getClient_id() + ":" + properties.getClient_secret();
             byte[] authEncBytes = Base64.encodeBase64(auth.getBytes());
             String authStringEnc = new String(authEncBytes);
             String authHeader = "Basic " + authStringEnc;
@@ -139,15 +130,15 @@ public class CodefService extends EasyCodefConstant {
     /**
      * 기본 요청 값 세팅
      **/
-    private JSONObject setRequestJsonObject(CodefApiRequest request) throws Exception {
+    private JSONObject setRequestJsonObject(CodefApiRequest request){
         JSONObject jsonRequest = new JSONObject();
         jsonRequest.put("organization", "0004");
 
         // 사용자 관련
         jsonRequest.put("loginType", "0");
         jsonRequest.put("certType", "pfx");
-        jsonRequest.put("certFile", certFile);
-        jsonRequest.put("certPassword", rsaUtil.encryptRSA(password, publicKey));
+        jsonRequest.put("certFile", properties.getClient_pfx());
+        jsonRequest.put("certPassword", rsaUtil.encryptRSA(properties.getClient_password(), properties.getClient_publickey()));
         jsonRequest.put("supplierRegNumber", request.suId());
         jsonRequest.put("contractorRegNumber", request.ipId());
         jsonRequest.put("approvalNo", request.issueId());

--- a/src/main/java/SeoulMilk1_BE/nts_tax/service/CodefService.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/service/CodefService.java
@@ -151,7 +151,7 @@ public class CodefService extends EasyCodefConstant {
         jsonRequest.put("supplierRegNumber", request.suId());
         jsonRequest.put("contractorRegNumber", request.ipId());
         jsonRequest.put("approvalNo", request.issueId());
-        jsonRequest.put("reportingDate", request.transDate());
+        jsonRequest.put("reportingDate", request.issueDate());
         jsonRequest.put("supplyValue", request.chargeTotal());
 
         return jsonRequest;

--- a/src/main/java/SeoulMilk1_BE/nts_tax/service/CodefService.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/service/CodefService.java
@@ -30,19 +30,6 @@ public class CodefService extends EasyCodefConstant {
     private final CodefConfigProperties properties;
     private final RSAUtil rsaUtil;
 
-    private static final URL url;
-
-    /**
-     제3자 발급 사실 조회 OpenAPI URL 세팅
-     **/
-    static {
-        try {
-            url = new URL("https://development.codef.io/v1/kr/public/nt/third-party/tax-invoice-issue");
-        } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     public String validateNtsTax(CodefApiRequest request) {
         String accessToken = (String) publishToken().get("access_token");
         String result = getIssuedTaxInvoiceInfo(accessToken, request);
@@ -166,6 +153,7 @@ public class CodefService extends EasyCodefConstant {
     private String getIssuedTaxInvoiceInfo(String accessToken, CodefApiRequest request) {
         BufferedReader br = null;
         try {
+            URL url = new URL(properties.getClient_url());
             HttpURLConnection con = getHttpURLConnection(accessToken, url);
 
 

--- a/src/main/java/SeoulMilk1_BE/nts_tax/service/CodefService.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/service/CodefService.java
@@ -1,7 +1,6 @@
 package SeoulMilk1_BE.nts_tax.service;
 
 import SeoulMilk1_BE.auth.util.RSAUtil;
-import SeoulMilk1_BE.nts_tax.domain.NtsTax;
 import SeoulMilk1_BE.nts_tax.dto.request.CodefApiRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -39,7 +38,6 @@ public class CodefService extends EasyCodefConstant {
     @Value("${codef.client-publickey}")
     private String publicKey;
     private final RSAUtil rsaUtil;
-    private final NtsTaxService ntsTaxService;
 
     private static final URL url;
 

--- a/src/main/java/SeoulMilk1_BE/nts_tax/service/CodefService.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/service/CodefService.java
@@ -54,24 +54,21 @@ public class CodefService extends EasyCodefConstant {
         }
     }
 
-    public JsonNode validateNtsTax(Long id) {
-        NtsTax ntsTax = ntsTaxService.findById(id);
-        CodefApiRequest request = CodefApiRequest.of(ntsTax.getSuId(), ntsTax.getIpId(), ntsTax.getIssueId(), ntsTax.getChargeTotal(), ntsTax.getTransDate());
-
+    public String validateNtsTax(CodefApiRequest request) {
         String accessToken = (String) publishToken().get("access_token");
-        String resultLv1 = getIssuedTaxInvoiceInfo(accessToken, request);
-        return decodeResult(resultLv1);
+        String result = getIssuedTaxInvoiceInfo(accessToken, request);
+        return extractResult(result);
     }
 
     /**
      * 결과 값 디코딩
      **/
-    private JsonNode decodeResult(String result) {
+    private String extractResult(String result) {
         try {
             String decode = URLDecoder.decode(result, StandardCharsets.UTF_8);
             ObjectMapper mapper = new ObjectMapper();
             JsonNode jsonNode = mapper.readTree(decode);
-            return jsonNode;
+            return jsonNode.path("result").path("message").asText();
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/service/NtsTaxService.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/service/NtsTaxService.java
@@ -1,11 +1,9 @@
 package SeoulMilk1_BE.nts_tax.service;
 
-import SeoulMilk1_BE.global.apiPayload.code.status.ErrorStatus;
 import SeoulMilk1_BE.global.apiPayload.exception.GeneralException;
 import SeoulMilk1_BE.nts_tax.domain.NtsTax;
 import SeoulMilk1_BE.nts_tax.dto.request.CodefApiRequest;
 import SeoulMilk1_BE.nts_tax.dto.request.UpdateTaxRequest;
-import SeoulMilk1_BE.nts_tax.dto.response.PaymentResolutionResponse;
 import SeoulMilk1_BE.nts_tax.exception.NtsTaxNotFoundException;
 import SeoulMilk1_BE.nts_tax.repository.NtsTaxRepository;
 import SeoulMilk1_BE.nts_tax.dto.response.OcrApiResponse;

--- a/src/main/java/SeoulMilk1_BE/nts_tax/service/NtsTaxService.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/service/NtsTaxService.java
@@ -1,7 +1,11 @@
 package SeoulMilk1_BE.nts_tax.service;
 
+import SeoulMilk1_BE.global.apiPayload.code.status.ErrorStatus;
+import SeoulMilk1_BE.global.apiPayload.exception.GeneralException;
 import SeoulMilk1_BE.nts_tax.domain.NtsTax;
+import SeoulMilk1_BE.nts_tax.dto.request.CodefApiRequest;
 import SeoulMilk1_BE.nts_tax.dto.request.UpdateTaxRequest;
+import SeoulMilk1_BE.nts_tax.dto.response.PaymentResolutionResponse;
 import SeoulMilk1_BE.nts_tax.exception.NtsTaxNotFoundException;
 import SeoulMilk1_BE.nts_tax.repository.NtsTaxRepository;
 import SeoulMilk1_BE.nts_tax.dto.response.OcrApiResponse;
@@ -12,8 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static SeoulMilk1_BE.global.apiPayload.code.status.ErrorStatus.TAX_NOT_FOUND;
-import static SeoulMilk1_BE.nts_tax.util.TaxConstants.DELETE_SUCCESS;
-import static SeoulMilk1_BE.nts_tax.util.TaxConstants.UPDATE_SUCCESS;
+import static SeoulMilk1_BE.nts_tax.util.TaxConstants.*;
 
 @Service
 @RequiredArgsConstructor
@@ -22,6 +25,7 @@ public class NtsTaxService {
 
     private final NtsTaxRepository ntsTaxRepository;
     private final UserService userService;
+    private final CodefService codefService;
 
     @Transactional
     public NtsTax saveNtsTax(OcrApiResponse ocrApiResponse, Long userId, String imageUrl) {
@@ -57,5 +61,20 @@ public class NtsTaxService {
     public NtsTax findByIssueId(String issueId) {
         return ntsTaxRepository.findByIssueId(issueId)
                 .orElseThrow(() -> new NtsTaxNotFoundException(TAX_NOT_FOUND));
+    }
+
+    @Transactional
+    public String validateNtsTax(Long ntsTaxId) {
+        NtsTax ntsTax = ntsTaxRepository.findById(ntsTaxId).orElseThrow(() -> new GeneralException(TAX_NOT_FOUND));
+        CodefApiRequest request = CodefApiRequest.of(ntsTax.getSuId(), ntsTax.getIpId(), ntsTax.getIssueId(), ntsTax.getChargeTotal(), ntsTax.getTransDate());
+        String result = codefService.validateNtsTax(request);
+
+        if (result.equals("성공")) {
+            ntsTax.updateStatus(0);
+        } else {
+            ntsTax.updateStatus(1);
+        }
+
+        return VALIDATE_SUCCESS.getMessage();
     }
 }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/service/NtsTaxService.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/service/NtsTaxService.java
@@ -64,7 +64,7 @@ public class NtsTaxService {
     @Transactional
     public String validateNtsTax(Long ntsTaxId) {
         NtsTax ntsTax = ntsTaxRepository.findById(ntsTaxId).orElseThrow(() -> new GeneralException(TAX_NOT_FOUND));
-        CodefApiRequest request = CodefApiRequest.of(ntsTax.getSuId(), ntsTax.getIpId(), ntsTax.getIssueId(), ntsTax.getChargeTotal(), ntsTax.getTransDate());
+        CodefApiRequest request = CodefApiRequest.of(ntsTax.getSuId(), ntsTax.getIpId(), ntsTax.getIssueId(), ntsTax.getChargeTotal(), ntsTax.getIssueDate());
         String result = codefService.validateNtsTax(request);
 
         if (result.equals("성공")) {

--- a/src/main/java/SeoulMilk1_BE/nts_tax/service/NtsTaxService.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/service/NtsTaxService.java
@@ -64,7 +64,7 @@ public class NtsTaxService {
     @Transactional
     public String validateNtsTax(Long ntsTaxId) {
         NtsTax ntsTax = ntsTaxRepository.findById(ntsTaxId).orElseThrow(() -> new GeneralException(TAX_NOT_FOUND));
-        CodefApiRequest request = CodefApiRequest.of(ntsTax.getSuId(), ntsTax.getIpId(), ntsTax.getIssueId(), ntsTax.getChargeTotal(), ntsTax.getIssueDate());
+        CodefApiRequest request = CodefApiRequest.from(ntsTax);
         String result = codefService.validateNtsTax(request);
 
         if (result.equals("성공")) {

--- a/src/main/java/SeoulMilk1_BE/nts_tax/util/CodefConfigProperties.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/util/CodefConfigProperties.java
@@ -13,4 +13,5 @@ public class CodefConfigProperties {
     private String client_password;
     private String client_publickey;
     private String client_pfx;
+    private String client_url;
 }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/util/CodefConfigProperties.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/util/CodefConfigProperties.java
@@ -1,0 +1,16 @@
+package SeoulMilk1_BE.nts_tax.util;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "codef")
+@Data
+public class CodefConfigProperties {
+    private String client_id;
+    private String client_secret;
+    private String client_password;
+    private String client_publickey;
+    private String client_pfx;
+}

--- a/src/main/java/SeoulMilk1_BE/nts_tax/util/TaxConstants.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/util/TaxConstants.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum TaxConstants {
     UPDATE_SUCCESS("세금명세서 정보 수정이 되었습니다."),
     DELETE_SUCCESS("해당 세금명세서가 삭제 되었습니다."),
+    VALIDATE_SUCCESS("세금계산서 검증이 완료되었습니다"),
     ;
 
     private final String message;


### PR DESCRIPTION
## Issue

- #17 


## Summary

- CODEF의 제3자 전자세금계산서 발급 사실 조회 Open API를 활용하여, 업로드된 세금계산서 검증을 수행하였습니다.
- CODEF 관련 의존성 추가 및 config를 세팅했습니다.
- API 사용 시에 필요한 RSA 암호화 관련 Util 클래스를 추가하였습니다.
- 검증하려는 세금계산서 id를 넣어서 요청 시, 검증 결과를 리턴 받도록 하였습니다.

## Describe your code

- api 테스트 결과
<img width="1146" alt="스크린샷 2025-03-03 오후 5 33 08" src="https://github.com/user-attachments/assets/62f62d52-641b-4bf3-b21b-a5817ec79cbf" />

# Check
- [x] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
