### PR TITLE
[FEATURE] 대리점 세금계산서 조회 기능

### DIFF
--- a/src/main/java/SeoulMilk1_BE/auth/controller/AuthController.java
+++ b/src/main/java/SeoulMilk1_BE/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package SeoulMilk1_BE.auth.controller;
 import SeoulMilk1_BE.auth.dto.request.LoginRequest;
 import SeoulMilk1_BE.auth.dto.request.SignUpRequest;
 import SeoulMilk1_BE.auth.dto.response.LoginResponse;
+import SeoulMilk1_BE.auth.dto.response.SearchCsNameResponseList;
 import SeoulMilk1_BE.auth.service.AuthService;
 import SeoulMilk1_BE.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -38,6 +39,12 @@ public class AuthController {
     @GetMapping("/validation/employee-id")
     public ApiResponse<?> validateEmployeeId(@Valid @RequestParam Long employeeId) {
         return ApiResponse.onSuccess(authService.validateEmployeeId(employeeId));
+    }
+
+    @Operation(summary = "모든 대리점명 조회", description = "모든 대리점 이름을 리스트로 제공합니다.")
+    @GetMapping("/search/cs")
+    public ApiResponse<SearchCsNameResponseList> searchCs() {
+        return ApiResponse.onSuccess(authService.searchCsName());
     }
 
     @Operation(summary = "회원가입", description = "ROLE에 관리자라면 ADMIN, 본사 사용자라면 HQ_USER, 대리점 사용자라면 CS_USER를 입력해주세요.")

--- a/src/main/java/SeoulMilk1_BE/auth/controller/AuthController.java
+++ b/src/main/java/SeoulMilk1_BE/auth/controller/AuthController.java
@@ -40,7 +40,7 @@ public class AuthController {
         return ApiResponse.onSuccess(authService.validateEmployeeId(employeeId));
     }
 
-    @Operation(summary = "회원가입", description = "ROLE에 관리자라면 ADMIN, 본사 사용자라면 HQ_USER, 고객센터 사용자라면 CS_USER를 입력해주세요.")
+    @Operation(summary = "회원가입", description = "ROLE에 관리자라면 ADMIN, 본사 사용자라면 HQ_USER, 대리점 사용자라면 CS_USER를 입력해주세요.")
     @PostMapping("/sign-up")
     public ApiResponse<?> signUp(@Valid @RequestBody SignUpRequest request) {
         return ApiResponse.onSuccess(authService.signUp(request));

--- a/src/main/java/SeoulMilk1_BE/auth/controller/AuthController.java
+++ b/src/main/java/SeoulMilk1_BE/auth/controller/AuthController.java
@@ -1,7 +1,8 @@
 package SeoulMilk1_BE.auth.controller;
 
 import SeoulMilk1_BE.auth.dto.request.LoginRequest;
-import SeoulMilk1_BE.auth.dto.request.SignUpRequest;
+import SeoulMilk1_BE.auth.dto.request.SignUpCSRequest;
+import SeoulMilk1_BE.auth.dto.request.SignUpHQRequest;
 import SeoulMilk1_BE.auth.dto.response.LoginResponse;
 import SeoulMilk1_BE.auth.dto.response.SearchCsNameResponseList;
 import SeoulMilk1_BE.auth.service.AuthService;
@@ -47,10 +48,16 @@ public class AuthController {
         return ApiResponse.onSuccess(authService.searchCsName());
     }
 
-    @Operation(summary = "회원가입", description = "ROLE에 관리자라면 ADMIN, 본사 사용자라면 HQ_USER, 대리점 사용자라면 CS_USER를 입력해주세요.")
-    @PostMapping("/sign-up")
-    public ApiResponse<?> signUp(@Valid @RequestBody SignUpRequest request) {
-        return ApiResponse.onSuccess(authService.signUp(request));
+    @Operation(summary = "본사 회원가입", description = "본사 회원가입 API입니다.")
+    @PostMapping("/sign-up/hq")
+    public ApiResponse<?> signUp(@Valid @RequestBody SignUpHQRequest request) {
+        return ApiResponse.onSuccess(authService.signUpHQ(request));
+    }
+
+    @Operation(summary = "대리점 회원가입", description = "대리점 회원가입 API입니다.")
+    @PostMapping("/sign-up/cs")
+    public ApiResponse<?> signUp(@Valid @RequestBody SignUpCSRequest request) {
+        return ApiResponse.onSuccess(authService.signUpCS(request));
     }
 
     @Operation(summary = "로그인", description = "access token은 header에 Authorization: Bearer 로, refresh token은 쿠키로 전달됩니다. <br><br>" +

--- a/src/main/java/SeoulMilk1_BE/auth/dto/request/SignUpCSRequest.java
+++ b/src/main/java/SeoulMilk1_BE/auth/dto/request/SignUpCSRequest.java
@@ -2,14 +2,15 @@ package SeoulMilk1_BE.auth.dto.request;
 
 import SeoulMilk1_BE.user.domain.Team;
 import SeoulMilk1_BE.user.domain.User;
-import SeoulMilk1_BE.user.domain.type.Role;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-public record SignUpRequest(
+import static SeoulMilk1_BE.user.domain.type.Role.CS_USER;
+
+public record SignUpCSRequest(
         Long employeeId,
         @Size(min = 8, max = 16, message = "비밀번호는 8자 이상 16자 이하로 입력해주세요")
         @NotBlank(message = "비밀번호를 입력해주세요")
@@ -20,19 +21,19 @@ public record SignUpRequest(
         @Email(message = "이메일 형식을 맞춰주세요")
         String email,
         String phone,
-        Role role,
         Long csId,
         String bank,
         String account
 ) {
-    public User toUser(PasswordEncoder passwordEncoder) {
+    public User toUser(PasswordEncoder passwordEncoder, Team team) {
         return User.builder()
                 .employeeId(employeeId)
                 .password(passwordEncoder.encode(password))
                 .name(name)
                 .email(email)
                 .phone(phone)
-                .role(role)
+                .role(CS_USER)
+                .team(team)
                 .isAssigned(false)
                 .build();
     }

--- a/src/main/java/SeoulMilk1_BE/auth/dto/request/SignUpHQRequest.java
+++ b/src/main/java/SeoulMilk1_BE/auth/dto/request/SignUpHQRequest.java
@@ -1,0 +1,35 @@
+package SeoulMilk1_BE.auth.dto.request;
+
+import SeoulMilk1_BE.user.domain.User;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static SeoulMilk1_BE.user.domain.type.Role.HQ_USER;
+
+public record SignUpHQRequest(
+        Long employeeId,
+        @Size(min = 8, max = 16, message = "비밀번호는 8자 이상 16자 이하로 입력해주세요")
+        @NotBlank(message = "비밀번호를 입력해주세요")
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@!%?&])[A-Za-z\\d@!%?&]{8,16}$",
+                message = "비밀번호는 영문, 숫자, 특수문자의 조합으로 입력해주세요")
+        String password,
+        String name,
+        @Email(message = "이메일 형식을 맞춰주세요")
+        String email,
+        String phone
+) {
+    public User toUser(PasswordEncoder passwordEncoder) {
+        return User.builder()
+                .employeeId(employeeId)
+                .password(passwordEncoder.encode(password))
+                .name(name)
+                .email(email)
+                .phone(phone)
+                .role(HQ_USER)
+                .isAssigned(false)
+                .build();
+    }
+}

--- a/src/main/java/SeoulMilk1_BE/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/SeoulMilk1_BE/auth/dto/request/SignUpRequest.java
@@ -21,7 +21,9 @@ public record SignUpRequest(
         String email,
         String phone,
         Role role,
-        Team team
+        Long csId,
+        String bank,
+        String account
 ) {
     public User toUser(PasswordEncoder passwordEncoder) {
         return User.builder()
@@ -31,7 +33,6 @@ public record SignUpRequest(
                 .email(email)
                 .phone(phone)
                 .role(role)
-                .team(team)
                 .isAssigned(false)
                 .build();
     }

--- a/src/main/java/SeoulMilk1_BE/auth/dto/response/SearchCsNameResponse.java
+++ b/src/main/java/SeoulMilk1_BE/auth/dto/response/SearchCsNameResponse.java
@@ -1,0 +1,17 @@
+package SeoulMilk1_BE.auth.dto.response;
+
+import SeoulMilk1_BE.user.domain.Team;
+import lombok.Builder;
+
+@Builder
+public record SearchCsNameResponse(
+        Long csId,
+        String csName
+) {
+    public static SearchCsNameResponse from(Team team) {
+        return SearchCsNameResponse.builder()
+                .csId(team.getId())
+                .csName(team.getName())
+                .build();
+    }
+}

--- a/src/main/java/SeoulMilk1_BE/auth/dto/response/SearchCsNameResponseList.java
+++ b/src/main/java/SeoulMilk1_BE/auth/dto/response/SearchCsNameResponseList.java
@@ -1,0 +1,16 @@
+package SeoulMilk1_BE.auth.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record SearchCsNameResponseList(
+        List<SearchCsNameResponse> responseList
+) {
+    public static SearchCsNameResponseList from(List<SearchCsNameResponse> responseList) {
+        return SearchCsNameResponseList.builder()
+                .responseList(responseList)
+                .build();
+    }
+}

--- a/src/main/java/SeoulMilk1_BE/auth/service/AuthService.java
+++ b/src/main/java/SeoulMilk1_BE/auth/service/AuthService.java
@@ -1,7 +1,8 @@
 package SeoulMilk1_BE.auth.service;
 
 import SeoulMilk1_BE.auth.dto.request.LoginRequest;
-import SeoulMilk1_BE.auth.dto.request.SignUpRequest;
+import SeoulMilk1_BE.auth.dto.request.SignUpCSRequest;
+import SeoulMilk1_BE.auth.dto.request.SignUpHQRequest;
 import SeoulMilk1_BE.auth.dto.response.LoginResponse;
 import SeoulMilk1_BE.auth.dto.response.SearchCsNameResponse;
 import SeoulMilk1_BE.auth.dto.response.SearchCsNameResponseList;
@@ -62,16 +63,21 @@ public class AuthService {
     }
 
     @Transactional
-    public String signUp(SignUpRequest request) {
+    public String signUpHQ(SignUpHQRequest request) {
         User user = request.toUser(passwordEncoder);
         userRepository.save(user);
 
-        if (user.getRole() == CS_USER) {
-            Team team = teamRepository.findById(request.csId())
-                    .orElseThrow(() -> new TeamNotFoundException(TEAM_NOT_FOUND));
+        return PENDING.getMessage();
+    }
 
-            team.updateTeam(request.bank(), request.account());
-        }
+    @Transactional
+    public String signUpCS(SignUpCSRequest request) {
+        Team team = teamRepository.findById(request.csId())
+                .orElseThrow(() -> new TeamNotFoundException(TEAM_NOT_FOUND));
+        team.updateTeam(request.bank(), request.account());
+
+        User user = request.toUser(passwordEncoder, team);
+        userRepository.save(user);
 
         return PENDING.getMessage();
     }

--- a/src/main/java/SeoulMilk1_BE/auth/service/AuthService.java
+++ b/src/main/java/SeoulMilk1_BE/auth/service/AuthService.java
@@ -3,10 +3,13 @@ package SeoulMilk1_BE.auth.service;
 import SeoulMilk1_BE.auth.dto.request.LoginRequest;
 import SeoulMilk1_BE.auth.dto.request.SignUpRequest;
 import SeoulMilk1_BE.auth.dto.response.LoginResponse;
+import SeoulMilk1_BE.auth.dto.response.SearchCsNameResponse;
+import SeoulMilk1_BE.auth.dto.response.SearchCsNameResponseList;
 import SeoulMilk1_BE.auth.util.JwtTokenProvider;
 import SeoulMilk1_BE.user.domain.User;
 import SeoulMilk1_BE.user.exception.PasswordNotMatchException;
 import SeoulMilk1_BE.user.exception.UserNotFoundException;
+import SeoulMilk1_BE.user.repository.TeamRepository;
 import SeoulMilk1_BE.user.repository.UserRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +17,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static SeoulMilk1_BE.global.apiPayload.code.status.ErrorStatus.PASSWORD_NOT_MATCH;
 import static SeoulMilk1_BE.global.apiPayload.code.status.ErrorStatus.USER_NOT_FOUND;
@@ -27,6 +32,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
+    private final TeamRepository teamRepository;
 
     public String getTestToken(Long userId) {
         User user = userRepository.findById(userId)
@@ -43,6 +49,14 @@ public class AuthService {
         }
 
         return message;
+    }
+
+    public SearchCsNameResponseList searchCsName() {
+        List<SearchCsNameResponse> responseList = teamRepository.findAll().stream()
+                .map(SearchCsNameResponse::from)
+                .toList();
+
+        return SearchCsNameResponseList.from(responseList);
     }
 
     @Transactional

--- a/src/main/java/SeoulMilk1_BE/auth/service/AuthService.java
+++ b/src/main/java/SeoulMilk1_BE/auth/service/AuthService.java
@@ -6,8 +6,10 @@ import SeoulMilk1_BE.auth.dto.response.LoginResponse;
 import SeoulMilk1_BE.auth.dto.response.SearchCsNameResponse;
 import SeoulMilk1_BE.auth.dto.response.SearchCsNameResponseList;
 import SeoulMilk1_BE.auth.util.JwtTokenProvider;
+import SeoulMilk1_BE.user.domain.Team;
 import SeoulMilk1_BE.user.domain.User;
 import SeoulMilk1_BE.user.exception.PasswordNotMatchException;
+import SeoulMilk1_BE.user.exception.TeamNotFoundException;
 import SeoulMilk1_BE.user.exception.UserNotFoundException;
 import SeoulMilk1_BE.user.repository.TeamRepository;
 import SeoulMilk1_BE.user.repository.UserRepository;
@@ -20,8 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static SeoulMilk1_BE.global.apiPayload.code.status.ErrorStatus.PASSWORD_NOT_MATCH;
-import static SeoulMilk1_BE.global.apiPayload.code.status.ErrorStatus.USER_NOT_FOUND;
+import static SeoulMilk1_BE.global.apiPayload.code.status.ErrorStatus.*;
+import static SeoulMilk1_BE.user.domain.type.Role.CS_USER;
 import static SeoulMilk1_BE.user.util.UserConstants.*;
 
 @Slf4j
@@ -63,6 +65,13 @@ public class AuthService {
     public String signUp(SignUpRequest request) {
         User user = request.toUser(passwordEncoder);
         userRepository.save(user);
+
+        if (user.getRole() == CS_USER) {
+            Team team = teamRepository.findById(request.csId())
+                    .orElseThrow(() -> new TeamNotFoundException(TEAM_NOT_FOUND));
+
+            team.updateTeam(request.bank(), request.account());
+        }
 
         return PENDING.getMessage();
     }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/controller/NtsTaxController.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/controller/NtsTaxController.java
@@ -33,7 +33,7 @@ public class NtsTaxController {
         return ApiResponse.onSuccess(ocrService.callOcrApi(userId, file));
     }
 
-    @Operation(summary = "세금명세서 검증", description = "검증할 세금계산서 id를 PathVariable로 넘겨주세요!!")
+    @Operation(summary = "세금계산서 검증", description = "검증할 세금계산서 id를 PathVariable로 넘겨주세요!!")
     @PostMapping(path = "/validate/{ntsTaxId}")
     public ApiResponse<String> validateNtsTax(
             @PathVariable("ntsTaxId") Long ntsTaxId
@@ -41,7 +41,7 @@ public class NtsTaxController {
         return ApiResponse.onSuccess(ntsTaxService.validateNtsTax(ntsTaxId));
     }
 
-    @Operation(summary = "세금명세서 수정", description = "OCR에서 추출한 텍스트를 수정")
+    @Operation(summary = "세금계산서 수정", description = "OCR에서 추출한 텍스트를 수정")
     @PutMapping("/{ntsTaxId}")
     public ApiResponse<String> updateNtsTax(
             @PathVariable Long ntsTaxId,
@@ -50,7 +50,7 @@ public class NtsTaxController {
         return ApiResponse.onSuccess(ntsTaxService.updateNtsTax(ntsTaxId, request));
     }
 
-    @Operation(summary = "세금명세서 삭제", description = "세금명세서를 DB에서 삭제")
+    @Operation(summary = "세금계산서 삭제", description = "세금계산서를 DB에서 삭제")
     @DeleteMapping("/{ntsTaxId}")
     public ApiResponse<String> deleteNtsTax(@PathVariable Long ntsTaxId) {
         return ApiResponse.onSuccess(ntsTaxService.deleteNtsTax(ntsTaxId));

--- a/src/main/java/SeoulMilk1_BE/nts_tax/domain/NtsTax.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/domain/NtsTax.java
@@ -31,7 +31,7 @@ public class NtsTax extends BaseTimeEntity {
     private Long id;
 
     @JoinColumn(name = "team_id")
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Team team;
 
     @Column(name = "issue_id", nullable = false, length = 24)

--- a/src/main/java/SeoulMilk1_BE/nts_tax/domain/NtsTax.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/domain/NtsTax.java
@@ -222,6 +222,7 @@ public class NtsTax extends BaseTimeEntity {
                 .erZet(LocalDateTime.now().format(DateTimeFormatter.ofPattern("HHmmss")))
                 .user(user)
                 .taxImgUrl(imageUrl)
+                .status(Status.WAIT)
                 .build();
     }
 

--- a/src/main/java/SeoulMilk1_BE/nts_tax/domain/type/Status.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/domain/type/Status.java
@@ -1,7 +1,16 @@
 package SeoulMilk1_BE.nts_tax.domain.type;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Status {
-    APPROVE,
-    REFUSED,
-    DONE
+    WAIT("승인대기"),
+    APPROVE("승인됨"),
+    REFUSED("반려됨"),
+    DONE("지급결의"),
+    ;
+
+    private final String message;
 }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/dto/response/CsSearchTaxResponse.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/dto/response/CsSearchTaxResponse.java
@@ -1,6 +1,7 @@
 package SeoulMilk1_BE.nts_tax.dto.response;
 
 import SeoulMilk1_BE.nts_tax.domain.NtsTax;
+import SeoulMilk1_BE.nts_tax.domain.type.Status;
 import lombok.Builder;
 
 @Builder
@@ -9,7 +10,8 @@ public record CsSearchTaxResponse(
         String title,
         String taxDate,
         String team,
-        String name
+        String name,
+        Status status
 ) {
     public static CsSearchTaxResponse from(NtsTax ntsTax) {
         return CsSearchTaxResponse.builder()
@@ -18,6 +20,7 @@ public record CsSearchTaxResponse(
                 .taxDate(ntsTax.getIssueDate())
                 .team(ntsTax.getSuDeptName())
                 .name(ntsTax.getSuPersName())
+                .status(ntsTax.getStatus())
                 .build();
     }
 }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/dto/response/CsSearchTaxResponse.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/dto/response/CsSearchTaxResponse.java
@@ -1,0 +1,23 @@
+package SeoulMilk1_BE.nts_tax.dto.response;
+
+import SeoulMilk1_BE.nts_tax.domain.NtsTax;
+import lombok.Builder;
+
+@Builder
+public record CsSearchTaxResponse(
+        Long ntsTaxId,
+        String title,
+        String taxDate,
+        String team,
+        String name
+) {
+    public static CsSearchTaxResponse from(NtsTax ntsTax) {
+        return CsSearchTaxResponse.builder()
+                .ntsTaxId(ntsTax.getId())
+                .title(ntsTax.getIssueDate())
+                .taxDate(ntsTax.getIssueDate())
+                .team(ntsTax.getSuDeptName())
+                .name(ntsTax.getSuPersName())
+                .build();
+    }
+}

--- a/src/main/java/SeoulMilk1_BE/nts_tax/dto/response/CsSearchTaxResponseList.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/dto/response/CsSearchTaxResponseList.java
@@ -1,0 +1,16 @@
+package SeoulMilk1_BE.nts_tax.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CsSearchTaxResponseList(
+        List<CsSearchTaxResponse> responseList
+) {
+    public static CsSearchTaxResponseList from(List<CsSearchTaxResponse> responseList) {
+        return CsSearchTaxResponseList.builder()
+                .responseList(responseList)
+                .build();
+    }
+}

--- a/src/main/java/SeoulMilk1_BE/nts_tax/dto/response/CsSearchTaxResponseList.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/dto/response/CsSearchTaxResponseList.java
@@ -6,10 +6,14 @@ import java.util.List;
 
 @Builder
 public record CsSearchTaxResponseList(
+        Long totalElements,
+        Integer totalPages,
         List<CsSearchTaxResponse> responseList
 ) {
-    public static CsSearchTaxResponseList from(List<CsSearchTaxResponse> responseList) {
+    public static CsSearchTaxResponseList of(Long totalElements, Integer totalPages, List<CsSearchTaxResponse> responseList) {
         return CsSearchTaxResponseList.builder()
+                .totalElements(totalElements)
+                .totalPages(totalPages)
                 .responseList(responseList)
                 .build();
     }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/dto/response/HqSearchTaxResponse.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/dto/response/HqSearchTaxResponse.java
@@ -1,6 +1,7 @@
 package SeoulMilk1_BE.nts_tax.dto.response;
 
 import SeoulMilk1_BE.nts_tax.domain.NtsTax;
+import SeoulMilk1_BE.nts_tax.domain.type.Status;
 import lombok.Builder;
 
 @Builder
@@ -9,7 +10,8 @@ public record HqSearchTaxResponse(
         String title,
         String taxDate,
         String team,
-        String name
+        String name,
+        Status status
 ) {
     public static HqSearchTaxResponse from(NtsTax ntsTax) {
         return HqSearchTaxResponse.builder()
@@ -18,6 +20,7 @@ public record HqSearchTaxResponse(
                 .taxDate(ntsTax.getIssueDate())
                 .team(ntsTax.getSuDeptName())
                 .name(ntsTax.getSuPersName())
+                .status(ntsTax.getStatus())
                 .build();
     }
 }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/dto/response/HqSearchTaxResponse.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/dto/response/HqSearchTaxResponse.java
@@ -1,0 +1,23 @@
+package SeoulMilk1_BE.nts_tax.dto.response;
+
+import SeoulMilk1_BE.nts_tax.domain.NtsTax;
+import lombok.Builder;
+
+@Builder
+public record HqSearchTaxResponse(
+        Long ntsTaxId,
+        String title,
+        String taxDate,
+        String team,
+        String name
+) {
+    public static HqSearchTaxResponse from(NtsTax ntsTax) {
+        return HqSearchTaxResponse.builder()
+                .ntsTaxId(ntsTax.getId())
+                .title(ntsTax.getIssueDate())
+                .taxDate(ntsTax.getIssueDate())
+                .team(ntsTax.getSuDeptName())
+                .name(ntsTax.getSuPersName())
+                .build();
+    }
+}

--- a/src/main/java/SeoulMilk1_BE/nts_tax/dto/response/HqSearchTaxResponseList.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/dto/response/HqSearchTaxResponseList.java
@@ -6,10 +6,14 @@ import java.util.List;
 
 @Builder
 public record HqSearchTaxResponseList(
+        Long totalElements,
+        Integer totalPages,
         List<HqSearchTaxResponse> responseList
 ) {
-    public static HqSearchTaxResponseList from(List<HqSearchTaxResponse> responseList) {
+    public static HqSearchTaxResponseList of(Long totalElements, Integer totalPages, List<HqSearchTaxResponse> responseList) {
         return HqSearchTaxResponseList.builder()
+                .totalElements(totalElements)
+                .totalPages(totalPages)
                 .responseList(responseList)
                 .build();
     }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/dto/response/HqSearchTaxResponseList.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/dto/response/HqSearchTaxResponseList.java
@@ -1,0 +1,16 @@
+package SeoulMilk1_BE.nts_tax.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record HqSearchTaxResponseList(
+        List<HqSearchTaxResponse> responseList
+) {
+    public static HqSearchTaxResponseList from(List<HqSearchTaxResponse> responseList) {
+        return HqSearchTaxResponseList.builder()
+                .responseList(responseList)
+                .build();
+    }
+}

--- a/src/main/java/SeoulMilk1_BE/nts_tax/dto/response/HqTaxResponse.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/dto/response/HqTaxResponse.java
@@ -18,7 +18,7 @@ public record HqTaxResponse(
         return HqTaxResponse.builder()
                 .ntsTaxId(ntsTax.getId())
                 .title(getMonth() + " 세금계산서")
-                .taxDate(getFormattedTaxDate(ntsTax))
+                .taxDate(getFormattedTaxDate(ntsTax.getIssueDate()))
                 .team(ntsTax.getSuDeptName())
                 .name(ntsTax.getSuPersName())
                 .build();
@@ -29,8 +29,7 @@ public record HqTaxResponse(
         return currentDate.format(DateTimeFormatter.ofPattern("MM월"));
     }
 
-    private static String getFormattedTaxDate(NtsTax ntsTax) {
-        String issueDate = ntsTax.getIssueDate();
+    private static String getFormattedTaxDate(String issueDate) {
         return issueDate.substring(0, 4) + "." + issueDate.substring(4, 6) + "." + issueDate.substring(6, 8);
     }
 }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/repository/NtsTaxRepository.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/repository/NtsTaxRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
-public interface NtsTaxRepository extends JpaRepository<NtsTax, Long> {
+public interface NtsTaxRepository extends JpaRepository<NtsTax, Long>, NtsTaxRepositoryCustom {
 
     Optional<NtsTax> findByIssueId(String issueId);
 

--- a/src/main/java/SeoulMilk1_BE/nts_tax/repository/NtsTaxRepositoryCustom.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/repository/NtsTaxRepositoryCustom.java
@@ -1,5 +1,6 @@
 package SeoulMilk1_BE.nts_tax.repository;
 
+import SeoulMilk1_BE.nts_tax.domain.type.Status;
 import SeoulMilk1_BE.nts_tax.dto.response.CsSearchTaxResponse;
 import SeoulMilk1_BE.nts_tax.dto.response.HqSearchTaxResponse;
 import org.springframework.data.domain.Page;
@@ -7,7 +8,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface NtsTaxRepositoryCustom {
 
-    Page<HqSearchTaxResponse> findTaxUsedInHQ(Pageable pageable, String keyword, String startDate, String endDate, Long months);
+    Page<HqSearchTaxResponse> findTaxUsedInHQ(Pageable pageable, String keyword, String startDate, String endDate, Long months, Status status);
 
     Page<CsSearchTaxResponse> findTaxUsedInCS(Pageable pageable, Long userId, String startDate, String endDate, Long months);
 }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/repository/NtsTaxRepositoryCustom.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/repository/NtsTaxRepositoryCustom.java
@@ -1,11 +1,13 @@
 package SeoulMilk1_BE.nts_tax.repository;
 
+import SeoulMilk1_BE.nts_tax.dto.response.HqSearchTaxResponse;
 import SeoulMilk1_BE.nts_tax.dto.response.HqTaxResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface NtsTaxRepositoryCustom {
 
+    Page<HqSearchTaxResponse> findTaxUsedInHQ(Pageable pageable, String keyword, String startDate, String endDate, Long months);
 
-    Page<HqTaxResponse> findTax(Pageable pageable, String keyword, String startDate, String endDate, Long months);
+    Page<HqTaxResponse> findTaxUsedInCS(Pageable pageable, Long userId, String startDate, String endDate, Long months);
 }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/repository/NtsTaxRepositoryCustom.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/repository/NtsTaxRepositoryCustom.java
@@ -1,7 +1,7 @@
 package SeoulMilk1_BE.nts_tax.repository;
 
+import SeoulMilk1_BE.nts_tax.dto.response.CsSearchTaxResponse;
 import SeoulMilk1_BE.nts_tax.dto.response.HqSearchTaxResponse;
-import SeoulMilk1_BE.nts_tax.dto.response.HqTaxResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -9,5 +9,5 @@ public interface NtsTaxRepositoryCustom {
 
     Page<HqSearchTaxResponse> findTaxUsedInHQ(Pageable pageable, String keyword, String startDate, String endDate, Long months);
 
-    Page<HqTaxResponse> findTaxUsedInCS(Pageable pageable, Long userId, String startDate, String endDate, Long months);
+    Page<CsSearchTaxResponse> findTaxUsedInCS(Pageable pageable, Long userId, String startDate, String endDate, Long months);
 }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/repository/NtsTaxRepositoryCustom.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/repository/NtsTaxRepositoryCustom.java
@@ -10,5 +10,5 @@ public interface NtsTaxRepositoryCustom {
 
     Page<HqSearchTaxResponse> findTaxUsedInHQ(Pageable pageable, String keyword, String startDate, String endDate, Long months, Status status);
 
-    Page<CsSearchTaxResponse> findTaxUsedInCS(Pageable pageable, Long userId, String startDate, String endDate, Long months);
+    Page<CsSearchTaxResponse> findTaxUsedInCS(Pageable pageable, Long userId, String startDate, String endDate, Long months, Status status);
 }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/repository/NtsTaxRepositoryImpl.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/repository/NtsTaxRepositoryImpl.java
@@ -1,7 +1,7 @@
 package SeoulMilk1_BE.nts_tax.repository;
 
+import SeoulMilk1_BE.nts_tax.dto.response.CsSearchTaxResponse;
 import SeoulMilk1_BE.nts_tax.dto.response.HqSearchTaxResponse;
-import SeoulMilk1_BE.nts_tax.dto.response.HqTaxResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -56,12 +56,12 @@ public class NtsTaxRepositoryImpl implements NtsTaxRepositoryCustom {
 
 
     @Override
-    public Page<HqTaxResponse> findTaxUsedInCS(Pageable pageable, Long userId, String startDate, String endDate, Long months) {
-        List<HqTaxResponse> results = queryFactory.select(
-                        Projections.constructor(HqTaxResponse.class,
+    public Page<CsSearchTaxResponse> findTaxUsedInCS(Pageable pageable, Long userId, String startDate, String endDate, Long months) {
+        List<CsSearchTaxResponse> results = queryFactory.select(
+                        Projections.constructor(CsSearchTaxResponse.class,
                                 ntsTax.id,
-                                Expressions.stringTemplate("CONCAT(SUBSTRING(issueDate, 5, 2), '월 세금계산서')").as("formattedIssueDate"),
-                                ntsTax.issueDate,
+                                Expressions.stringTemplate("CONCAT(SUBSTRING(issueDate, 3, 2), '년 ', SUBSTRING(issueDate, 5, 2), '월 세금계산서')").as("formattedTitle"),
+                                Expressions.stringTemplate("CONCAT(SUBSTRING(issueDate, 1, 4), '.', SUBSTRING(issueDate, 5, 2), '.', SUBSTRING(issueDate, 7, 2))").as("formattedIssueDate"),
                                 ntsTax.suDeptName,
                                 ntsTax.suPersName
                         )

--- a/src/main/java/SeoulMilk1_BE/nts_tax/repository/NtsTaxRepositoryImpl.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/repository/NtsTaxRepositoryImpl.java
@@ -30,7 +30,7 @@ public class NtsTaxRepositoryImpl implements NtsTaxRepositoryCustom {
         List<HqSearchTaxResponse> results = queryFactory.select(
                         Projections.constructor(HqSearchTaxResponse.class,
                                 ntsTax.id,
-                                Expressions.stringTemplate("CONCAT(SUBSTRING(issueDate, 3, 2), '년 ', SUBSTRING(issueDate, 5, 2), '월 세금계산서')").as("formattedTitle"),
+                                Expressions.stringTemplate("CONCAT(ntsTax.suDeptName, ' ', SUBSTRING(issueDate, 3, 2), '년 ', SUBSTRING(issueDate, 5, 2), '월 세금계산서')").as("formattedTitle"),
                                 Expressions.stringTemplate("CONCAT(SUBSTRING(issueDate, 1, 4), '.', SUBSTRING(issueDate, 5, 2), '.', SUBSTRING(issueDate, 7, 2))").as("formattedIssueDate"),
                                 ntsTax.suDeptName,
                                 ntsTax.suPersName
@@ -60,7 +60,7 @@ public class NtsTaxRepositoryImpl implements NtsTaxRepositoryCustom {
         List<CsSearchTaxResponse> results = queryFactory.select(
                         Projections.constructor(CsSearchTaxResponse.class,
                                 ntsTax.id,
-                                Expressions.stringTemplate("CONCAT(SUBSTRING(issueDate, 3, 2), '년 ', SUBSTRING(issueDate, 5, 2), '월 세금계산서')").as("formattedTitle"),
+                                Expressions.stringTemplate("CONCAT(ntsTax.suDeptName, ' ', SUBSTRING(issueDate, 3, 2), '년 ', SUBSTRING(issueDate, 5, 2), '월 세금계산서')").as("formattedTitle"),
                                 Expressions.stringTemplate("CONCAT(SUBSTRING(issueDate, 1, 4), '.', SUBSTRING(issueDate, 5, 2), '.', SUBSTRING(issueDate, 7, 2))").as("formattedIssueDate"),
                                 ntsTax.suDeptName,
                                 ntsTax.suPersName

--- a/src/main/java/SeoulMilk1_BE/nts_tax/repository/NtsTaxRepositoryImpl.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/repository/NtsTaxRepositoryImpl.java
@@ -128,6 +128,6 @@ public class NtsTaxRepositoryImpl implements NtsTaxRepositoryCustom {
             return ntsTax.status.eq(status);
         }
 
-        return null;
+        return ntsTax.status.eq(Status.APPROVE);
     }
 }

--- a/src/main/java/SeoulMilk1_BE/nts_tax/service/NtsTaxService.java
+++ b/src/main/java/SeoulMilk1_BE/nts_tax/service/NtsTaxService.java
@@ -1,6 +1,7 @@
 package SeoulMilk1_BE.nts_tax.service;
 
 import SeoulMilk1_BE.global.apiPayload.exception.GeneralException;
+import SeoulMilk1_BE.global.service.S3Service;
 import SeoulMilk1_BE.nts_tax.domain.NtsTax;
 import SeoulMilk1_BE.nts_tax.dto.request.CodefApiRequest;
 import SeoulMilk1_BE.nts_tax.dto.request.UpdateTaxRequest;
@@ -24,6 +25,7 @@ public class NtsTaxService {
     private final NtsTaxRepository ntsTaxRepository;
     private final UserService userService;
     private final CodefService codefService;
+    private final S3Service s3Service;
 
     @Transactional
     public NtsTax saveNtsTax(OcrApiResponse ocrApiResponse, Long userId, String imageUrl) {
@@ -46,6 +48,7 @@ public class NtsTaxService {
     @Transactional
     public String deleteNtsTax(Long ntsTaxId) {
         NtsTax ntsTax = findById(ntsTaxId);
+        s3Service.deleteImageFromS3(ntsTax.getTaxImgUrl());
         ntsTaxRepository.delete(ntsTax);
 
         return DELETE_SUCCESS.getMessage();

--- a/src/main/java/SeoulMilk1_BE/user/controller/AdminController.java
+++ b/src/main/java/SeoulMilk1_BE/user/controller/AdminController.java
@@ -22,7 +22,7 @@ public class AdminController {
     @Operation(summary = "승인 대기중인 본사/대리점 사용자 조회", description = "승인 대기중인 본사/대리점 사용자 조회 <br><br> " +
             "page : 조회할 페이지 번호 <br> " +
             "size : 한 페이지에 조회할 사용자 수")
-    @GetMapping("")
+    @GetMapping("/pending")
     public ApiResponse<PendingUserResponseList> findPendingUsers(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
@@ -33,7 +33,7 @@ public class AdminController {
     @Operation(summary = "본사/대리점 유저 조회", description = "본사/대리점 사용자 전체 조회 <br><br> " +
             "page : 조회할 페이지 번호 <br> " +
             "size : 한 페이지에 조회할 사용자 수")
-    @GetMapping("/pending")
+    @GetMapping("/user")
     public ApiResponse<UserManageResponseList> findAllUsers(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size

--- a/src/main/java/SeoulMilk1_BE/user/controller/AdminController.java
+++ b/src/main/java/SeoulMilk1_BE/user/controller/AdminController.java
@@ -2,8 +2,8 @@ package SeoulMilk1_BE.user.controller;
 
 import SeoulMilk1_BE.global.apiPayload.ApiResponse;
 import SeoulMilk1_BE.user.dto.response.PendingUserResponseList;
+import SeoulMilk1_BE.user.dto.response.UserManageResponseList;
 import SeoulMilk1_BE.user.service.AdminService;
-import SeoulMilk1_BE.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -22,12 +22,23 @@ public class AdminController {
     @Operation(summary = "승인 대기중인 본사/대리점 사용자 조회", description = "승인 대기중인 본사/대리점 사용자 조회 <br><br> " +
             "page : 조회할 페이지 번호 <br> " +
             "size : 한 페이지에 조회할 사용자 수")
-    @GetMapping("/pending")
+    @GetMapping("")
     public ApiResponse<PendingUserResponseList> findPendingUsers(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
         return ApiResponse.onSuccess(adminService.findPendingUsers(page, size));
+    }
+
+    @Operation(summary = "본사/대리점 유저 조회", description = "본사/대리점 사용자 전체 조회 <br><br> " +
+            "page : 조회할 페이지 번호 <br> " +
+            "size : 한 페이지에 조회할 사용자 수")
+    @GetMapping("/pending")
+    public ApiResponse<UserManageResponseList> findAllUsers(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ApiResponse.onSuccess(adminService.findAllUsers(page, size));
     }
 
     @Operation(summary = "승인 대기중인 사용자 승인", description = "승인 대기중인 본사/대리점 사용자 승인")

--- a/src/main/java/SeoulMilk1_BE/user/controller/CsController.java
+++ b/src/main/java/SeoulMilk1_BE/user/controller/CsController.java
@@ -23,7 +23,8 @@ public class CsController {
 
     private final CsService csService;
 
-    @Operation(summary = "세금계산서 검색", description = "months : 기간(ex. 1개월, 3개월, 6개월 등)에 사용된 숫자를 입력해주세요 <br><br>" +
+    @Operation(summary = "세금계산서 검색", description = "검색 조건을 설정하지 않으면 세금계산서 전체 목록이 조회됩니다.<br><br>" +
+            "months : 기간(ex. 1개월, 3개월, 6개월 등)에 사용된 숫자를 입력해주세요 <br><br>" +
             "page : 조회할 페이지 번호 <br> size : 한 페이지에 조회할 세금계산서 수")
     @GetMapping("/search/tax")
     public ApiResponse<CsSearchTaxResponseList> searchTax(

--- a/src/main/java/SeoulMilk1_BE/user/controller/CsController.java
+++ b/src/main/java/SeoulMilk1_BE/user/controller/CsController.java
@@ -1,6 +1,7 @@
 package SeoulMilk1_BE.user.controller;
 
 import SeoulMilk1_BE.global.apiPayload.ApiResponse;
+import SeoulMilk1_BE.nts_tax.domain.type.Status;
 import SeoulMilk1_BE.nts_tax.dto.response.CsSearchTaxResponseList;
 import SeoulMilk1_BE.user.service.CsService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -31,7 +32,8 @@ public class CsController {
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate,
-            @RequestParam(required = false) Long months) {
-        return ApiResponse.onSuccess(csService.searchTax(userId, page, size, startDate, endDate, months));
+            @RequestParam(required = false) Long months,
+            @RequestParam(required = false) Status status) {
+        return ApiResponse.onSuccess(csService.searchTax(userId, page, size, startDate, endDate, months, status));
     }
 }

--- a/src/main/java/SeoulMilk1_BE/user/controller/CsController.java
+++ b/src/main/java/SeoulMilk1_BE/user/controller/CsController.java
@@ -1,0 +1,37 @@
+package SeoulMilk1_BE.user.controller;
+
+import SeoulMilk1_BE.global.apiPayload.ApiResponse;
+import SeoulMilk1_BE.nts_tax.dto.response.CsSearchTaxResponseList;
+import SeoulMilk1_BE.user.service.CsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "CS", description = "대리점 관련 API")
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/cs")
+public class CsController {
+
+    private final CsService csService;
+
+    @Operation(summary = "세금계산서 검색", description = "months : 기간(ex. 1개월, 3개월, 6개월 등)에 사용된 숫자를 입력해주세요 <br><br>" +
+            "page : 조회할 페이지 번호 <br> size : 한 페이지에 조회할 세금계산서 수")
+    @GetMapping("/search/tax")
+    public ApiResponse<CsSearchTaxResponseList> searchTax(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate,
+            @RequestParam(required = false) Long months) {
+        return ApiResponse.onSuccess(csService.searchTax(userId, page, size, startDate, endDate, months));
+    }
+}

--- a/src/main/java/SeoulMilk1_BE/user/controller/HqController.java
+++ b/src/main/java/SeoulMilk1_BE/user/controller/HqController.java
@@ -1,6 +1,7 @@
 package SeoulMilk1_BE.user.controller;
 
 import SeoulMilk1_BE.global.apiPayload.ApiResponse;
+import SeoulMilk1_BE.nts_tax.domain.type.Status;
 import SeoulMilk1_BE.nts_tax.dto.response.HqSearchTaxResponseList;
 import SeoulMilk1_BE.nts_tax.dto.response.HqTaxResponseList;
 import SeoulMilk1_BE.user.dto.response.HqSearchCsNameResponseList;
@@ -43,8 +44,9 @@ public class HqController {
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate,
-            @RequestParam(required = false) Long months) {
-        return ApiResponse.onSuccess(hqService.searchTax(page, size, keyword, startDate, endDate, months));
+            @RequestParam(required = false) Long months,
+            @RequestParam(required = false) Status status) {
+        return ApiResponse.onSuccess(hqService.searchTax(page, size, keyword, startDate, endDate, months, status));
     }
 
     @Operation(summary = "대리점명 조회", description = "대리점 검색에 사용되는 키워드를 입력해주세요 <br>" +

--- a/src/main/java/SeoulMilk1_BE/user/controller/HqController.java
+++ b/src/main/java/SeoulMilk1_BE/user/controller/HqController.java
@@ -33,7 +33,7 @@ public class HqController {
         return ApiResponse.onSuccess(hqService.getTaxInfo(page, size));
     }
 
-    @Operation(summary = "세금계산서 검색", description = "keyword : 고객센터 검색에 사용된 키워드를 입력해주세요 <br>" +
+    @Operation(summary = "세금계산서 검색", description = "keyword : 대리점 검색에 사용된 키워드를 입력해주세요 <br>" +
             "months : 기간(ex. 1개월, 3개월, 6개월 등)에 사용된 숫자를 입력해주세요 <br><br>" +
             "page : 조회할 페이지 번호 <br> size : 한 페이지에 조회할 세금계산서 수")
     @GetMapping("/search/tax")
@@ -47,15 +47,15 @@ public class HqController {
         return ApiResponse.onSuccess(hqService.searchTax(page, size, keyword, startDate, endDate, months));
     }
 
-    @Operation(summary = "고객센터명 조회", description = "고객센터 지점 검색에 사용되는 키워드를 입력해주세요 <br>" +
-            "키워드를 포함하는 모든 고객센터 지점명이 제공됩니다")
+    @Operation(summary = "대리점명 조회", description = "대리점 검색에 사용되는 키워드를 입력해주세요 <br>" +
+            "키워드를 포함하는 모든 대리점명이 제공됩니다")
     @GetMapping("/search/cs/name")
     public ApiResponse<HqSearchCsNameResponseList> searchCs(@RequestParam(required = false) String keyword) {
         return ApiResponse.onSuccess(hqService.searchCsName(keyword));
     }
 
-    @Operation(summary = "고객센터 지점 조회", description = "키워드를 포함하는 고객센터 검색에 사용되는 API입니다 <br>" +
-            "고객센터 정보들이 제공됩니다")
+    @Operation(summary = "대리점 검색 및 조회", description = "키워드를 포함하는 대리점 검색에 사용되는 API입니다 <br>" +
+            "대리점 정보들이 제공됩니다")
     @GetMapping("/search/cs/info")
     public ApiResponse<HqSearchCsResponseList> searchCsInfo(@RequestParam(required = false) String keyword) {
         return ApiResponse.onSuccess(hqService.searchCs(keyword));

--- a/src/main/java/SeoulMilk1_BE/user/controller/HqController.java
+++ b/src/main/java/SeoulMilk1_BE/user/controller/HqController.java
@@ -34,7 +34,8 @@ public class HqController {
         return ApiResponse.onSuccess(hqService.getTaxInfo(page, size));
     }
 
-    @Operation(summary = "세금계산서 검색", description = "keyword : 대리점 검색에 사용된 키워드를 입력해주세요 <br>" +
+    @Operation(summary = "세금계산서 검색", description = "검색 조건을 설정하지 않으면 세금계산서 전체 목록이 조회됩니다.<br><br>" +
+            "keyword : 대리점 검색에 사용된 키워드를 입력해주세요 <br>" +
             "months : 기간(ex. 1개월, 3개월, 6개월 등)에 사용된 숫자를 입력해주세요 <br><br>" +
             "page : 조회할 페이지 번호 <br> size : 한 페이지에 조회할 세금계산서 수")
     @GetMapping("/search/tax")

--- a/src/main/java/SeoulMilk1_BE/user/controller/HqController.java
+++ b/src/main/java/SeoulMilk1_BE/user/controller/HqController.java
@@ -1,6 +1,7 @@
 package SeoulMilk1_BE.user.controller;
 
 import SeoulMilk1_BE.global.apiPayload.ApiResponse;
+import SeoulMilk1_BE.nts_tax.dto.response.HqSearchTaxResponseList;
 import SeoulMilk1_BE.nts_tax.dto.response.HqTaxResponseList;
 import SeoulMilk1_BE.user.dto.response.HqSearchCsNameResponseList;
 import SeoulMilk1_BE.user.dto.response.HqSearchCsResponseList;
@@ -36,7 +37,7 @@ public class HqController {
             "months : 기간(ex. 1개월, 3개월, 6개월 등)에 사용된 숫자를 입력해주세요 <br><br>" +
             "page : 조회할 페이지 번호 <br> size : 한 페이지에 조회할 세금계산서 수")
     @GetMapping("/search/tax")
-    public ApiResponse<HqTaxResponseList> searchTax(
+    public ApiResponse<HqSearchTaxResponseList> searchTax(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(required = false) String keyword,

--- a/src/main/java/SeoulMilk1_BE/user/controller/HqController.java
+++ b/src/main/java/SeoulMilk1_BE/user/controller/HqController.java
@@ -45,7 +45,7 @@ public class HqController {
             @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate,
             @RequestParam(required = false) Long months,
-            @RequestParam(required = false) Status status) {
+            @RequestParam(defaultValue = "APPROVE") Status status) {
         return ApiResponse.onSuccess(hqService.searchTax(page, size, keyword, startDate, endDate, months, status));
     }
 

--- a/src/main/java/SeoulMilk1_BE/user/controller/UserController.java
+++ b/src/main/java/SeoulMilk1_BE/user/controller/UserController.java
@@ -24,19 +24,19 @@ public class UserController {
 
     private final UserService userService;
 
-    @Operation(summary = "유저 정보 조회", description = "홈 화면의 사이드바 유저 정보 조회 (관리자, 본사 직원, 고객센터 직원 공통 사용)")
+    @Operation(summary = "유저 정보 조회", description = "홈 화면의 사이드바 유저 정보 조회 (관리자, 본사 직원, 대리점 직원 공통 사용)")
     @GetMapping("")
     public ApiResponse<UserResponse> getUserInfo(@AuthenticationPrincipal Long userId) {
         return ApiResponse.onSuccess(userService.getUserInfo(userId));
     }
 
-    @Operation(summary = "유저 상세 정보 조회", description = "유저 상세 정보 조회 (관리자, 본사 직원, 고객센터 직원 공통 사용)")
+    @Operation(summary = "유저 상세 정보 조회", description = "유저 상세 정보 조회 (관리자, 본사 직원, 대리점 직원 공통 사용)")
     @GetMapping("/detail")
     public ApiResponse<UserDetailResponse> getUserDetail(@AuthenticationPrincipal Long userId) {
         return ApiResponse.onSuccess(userService.getUserDetail(userId));
     }
 
-    @Operation(summary = "유저 정보 수정", description = "유저 정보 수정 (관리자, 고객센터 직원 공통 사용)")
+    @Operation(summary = "유저 정보 수정", description = "유저 정보 수정 (본사 직원, 대리점 직원 공통 사용)")
     @PutMapping("/update")
     public ApiResponse<String> updateUser(@AuthenticationPrincipal Long userId, UpdateUserRequest request) {
         return ApiResponse.onSuccess(userService.updateUser(userId, request));

--- a/src/main/java/SeoulMilk1_BE/user/controller/UserController.java
+++ b/src/main/java/SeoulMilk1_BE/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package SeoulMilk1_BE.user.controller;
 
 import SeoulMilk1_BE.global.apiPayload.ApiResponse;
+import SeoulMilk1_BE.user.dto.request.UpdateUserRequest;
 import SeoulMilk1_BE.user.dto.response.UserDetailResponse;
 import SeoulMilk1_BE.user.dto.response.UserResponse;
 import SeoulMilk1_BE.user.service.UserService;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -32,5 +34,11 @@ public class UserController {
     @GetMapping("/detail")
     public ApiResponse<UserDetailResponse> getUserDetail(@AuthenticationPrincipal Long userId) {
         return ApiResponse.onSuccess(userService.getUserDetail(userId));
+    }
+
+    @Operation(summary = "유저 정보 수정", description = "유저 정보 수정 (관리자, 고객센터 직원 공통 사용)")
+    @PutMapping("/update")
+    public ApiResponse<String> updateUser(@AuthenticationPrincipal Long userId, UpdateUserRequest request) {
+        return ApiResponse.onSuccess(userService.updateUser(userId, request));
     }
 }

--- a/src/main/java/SeoulMilk1_BE/user/controller/UserController.java
+++ b/src/main/java/SeoulMilk1_BE/user/controller/UserController.java
@@ -1,7 +1,7 @@
 package SeoulMilk1_BE.user.controller;
 
 import SeoulMilk1_BE.global.apiPayload.ApiResponse;
-import SeoulMilk1_BE.user.dto.response.PendingUserResponseList;
+import SeoulMilk1_BE.user.dto.response.UserDetailResponse;
 import SeoulMilk1_BE.user.dto.response.UserResponse;
 import SeoulMilk1_BE.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,7 +9,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "User", description = "유저 관련 공통 API")
 @Slf4j
@@ -20,9 +22,15 @@ public class UserController {
 
     private final UserService userService;
 
-    @Operation(summary = "유저 정보 조회", description = "홈 화면의 유저 정보 조회 (관리자, 본사 직원, 고객센터 직원 공통 사용)")
+    @Operation(summary = "유저 정보 조회", description = "홈 화면의 사이드바 유저 정보 조회 (관리자, 본사 직원, 고객센터 직원 공통 사용)")
     @GetMapping("")
     public ApiResponse<UserResponse> getUserInfo(@AuthenticationPrincipal Long userId) {
         return ApiResponse.onSuccess(userService.getUserInfo(userId));
+    }
+
+    @Operation(summary = "유저 상세 정보 조회", description = "유저 상세 정보 조회 (관리자, 본사 직원, 고객센터 직원 공통 사용)")
+    @GetMapping("/detail")
+    public ApiResponse<UserDetailResponse> getUserDetail(@AuthenticationPrincipal Long userId) {
+        return ApiResponse.onSuccess(userService.getUserDetail(userId));
     }
 }

--- a/src/main/java/SeoulMilk1_BE/user/domain/Team.java
+++ b/src/main/java/SeoulMilk1_BE/user/domain/Team.java
@@ -50,8 +50,8 @@ public class Team {
         this.account = account;
     }
 
-    public void updateTeam(UpdateUserRequest request) {
-        this.bank = request.bank();
-        this.account = request.account();
+    public void updateTeam(String bank, String account) {
+        this.bank = bank;
+        this.account = account;
     }
 }

--- a/src/main/java/SeoulMilk1_BE/user/domain/Team.java
+++ b/src/main/java/SeoulMilk1_BE/user/domain/Team.java
@@ -1,5 +1,6 @@
 package SeoulMilk1_BE.user.domain;
 
+import SeoulMilk1_BE.user.dto.request.UpdateUserRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -47,5 +48,10 @@ public class Team {
         this.businessNumber = businessNumber;
         this.bank = bank;
         this.account = account;
+    }
+
+    public void updateTeam(UpdateUserRequest request) {
+        this.bank = request.bank();
+        this.account = request.account();
     }
 }

--- a/src/main/java/SeoulMilk1_BE/user/domain/User.java
+++ b/src/main/java/SeoulMilk1_BE/user/domain/User.java
@@ -2,6 +2,7 @@ package SeoulMilk1_BE.user.domain;
 
 import SeoulMilk1_BE.global.domain.BaseTimeEntity;
 import SeoulMilk1_BE.user.domain.type.Role;
+import SeoulMilk1_BE.user.dto.request.UpdateUserRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -68,5 +69,16 @@ public class User extends BaseTimeEntity {
 
     public void assign() {
         this.isAssigned = true;
+    }
+
+    public void updateUser(UpdateUserRequest request) {
+        this.employeeId = request.employeeId();
+        this.email = request.email();
+        this.phone = formatPhone(request.phone());
+        this.account = request.account();
+    }
+
+    private static String formatPhone(String phone) {
+        return phone.replace("-", "");
     }
 }

--- a/src/main/java/SeoulMilk1_BE/user/dto/request/UpdateUserRequest.java
+++ b/src/main/java/SeoulMilk1_BE/user/dto/request/UpdateUserRequest.java
@@ -1,0 +1,10 @@
+package SeoulMilk1_BE.user.dto.request;
+
+public record UpdateUserRequest(
+        Long employeeId,
+        String email,
+        String phone,
+        String bank,
+        String account
+) {
+}

--- a/src/main/java/SeoulMilk1_BE/user/dto/response/PendingUserResponse.java
+++ b/src/main/java/SeoulMilk1_BE/user/dto/response/PendingUserResponse.java
@@ -25,7 +25,7 @@ public record PendingUserResponse(
                 .name(user.getName())
                 .phone(formatPhone(user.getPhone()))
                 .role(user.getRole())
-                .team(user.getTeam().getName())
+                .team(user.getTeam() != null ? user.getTeam().getName() : null)
                 .createdAt(formatCreatedAt(user.getCreatedAt()))
                 .build();
     }

--- a/src/main/java/SeoulMilk1_BE/user/dto/response/UserDetailResponse.java
+++ b/src/main/java/SeoulMilk1_BE/user/dto/response/UserDetailResponse.java
@@ -1,0 +1,49 @@
+package SeoulMilk1_BE.user.dto.response;
+
+import SeoulMilk1_BE.user.domain.User;
+import lombok.Builder;
+import org.springframework.util.StringUtils;
+
+import static SeoulMilk1_BE.user.domain.type.Role.*;
+
+@Builder
+public record UserDetailResponse(
+    Long userId,
+    String name,
+    String role,
+    String teamName,
+    Long employeeId,
+    String email,
+    String phone,
+    String bank,
+    String account
+) {
+    public static UserDetailResponse from(User user) {
+        UserDetailResponseBuilder response = UserDetailResponse.builder()
+            .userId(user.getId())
+            .name(user.getName())
+            .employeeId(user.getEmployeeId())
+            .email(user.getEmail())
+            .phone(formatPhoneNumber(user.getPhone()));
+
+        if (user.getRole() == ADMIN) {
+            response.role("관리자");
+        } else if (user.getRole() == HQ_USER) {
+            response.role("직원")
+                    .teamName(user.getTeam().getName());
+        } else {
+            response.teamName(user.getTeam().getName())
+                    .bank(user.getTeam().getBank())
+                    .account(user.getTeam().getAccount());
+        }
+
+        return response.build();
+    }
+
+    private static String formatPhoneNumber(String phoneNumber) {
+        if (!StringUtils.hasText(phoneNumber) || phoneNumber.length() != 11) {
+            return phoneNumber;
+        }
+        return phoneNumber.replaceFirst("(\\d{3})(\\d{4})(\\d{4})", "$1-$2-$3");
+    }
+}

--- a/src/main/java/SeoulMilk1_BE/user/dto/response/UserManageResponse.java
+++ b/src/main/java/SeoulMilk1_BE/user/dto/response/UserManageResponse.java
@@ -1,0 +1,50 @@
+package SeoulMilk1_BE.user.dto.response;
+
+import SeoulMilk1_BE.user.domain.User;
+import SeoulMilk1_BE.user.domain.type.Role;
+import lombok.Builder;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Builder
+public record UserManageResponse(
+        Long userId,
+        Long employeeId,
+        String name,
+        String phone,
+        Role role,
+        String csName,
+        String createdAt,
+        String isAssigned
+) {
+    public static UserManageResponse from(User user) {
+        return UserManageResponse.builder()
+                .userId(user.getId())
+                .employeeId(user.getEmployeeId())
+                .name(user.getName())
+                .phone(formatPhone(user.getPhone()))
+                .role(user.getRole())
+                .csName(user.getTeam() != null ? user.getTeam().getName() : null)
+                .createdAt(formatCreatedAt(user.getCreatedAt()))
+                .isAssigned(user.getIsAssigned() ? "등록" : "미등록")
+                .build();
+    }
+
+    private static String formatPhone(String phone) {
+        if (StringUtils.hasText(phone) && phone.matches("\\d{10,11}")) {
+            return phone.replaceFirst("(\\d{3})(\\d{4})(\\d{4})", "$1-$2-$3");
+        }
+        return phone;
+    }
+
+    private static String formatCreatedAt(LocalDateTime createdAt) {
+        if (createdAt != null) {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+            return createdAt.format(formatter);
+        }
+
+        return String.valueOf(createdAt);
+    }
+}

--- a/src/main/java/SeoulMilk1_BE/user/dto/response/UserManageResponseList.java
+++ b/src/main/java/SeoulMilk1_BE/user/dto/response/UserManageResponseList.java
@@ -1,0 +1,22 @@
+package SeoulMilk1_BE.user.dto.response;
+
+import SeoulMilk1_BE.user.domain.User;
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Builder
+public record UserManageResponseList(
+        Long totalElements,
+        Integer totalPages,
+        List<UserManageResponse> responseList
+) {
+    public static UserManageResponseList of(Page<User> page, List<UserManageResponse> responseList) {
+        return UserManageResponseList.builder()
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .responseList(responseList)
+                .build();
+    }
+}

--- a/src/main/java/SeoulMilk1_BE/user/repository/init/TeamInitializer.java
+++ b/src/main/java/SeoulMilk1_BE/user/repository/init/TeamInitializer.java
@@ -27,14 +27,6 @@ public class TeamInitializer implements ApplicationRunner {
         } else {
             List<Team> teamList = new ArrayList<>();
 
-            Team TEAM_ADMIN = Team.builder()
-                    .name("관리자")
-                    .build();
-
-            Team TEAM_HQ = Team.builder()
-                    .name("경영총괄팀")
-                    .build();
-
             Team TEAM_CS = Team.builder()
                     .name("서울우유용산고객센터")
                     .build();
@@ -55,8 +47,6 @@ public class TeamInitializer implements ApplicationRunner {
                     .name("서울우유대덕대리점")
                     .build();
 
-            teamList.add(TEAM_ADMIN);
-            teamList.add(TEAM_HQ);
             teamList.add(TEAM_CS);
             teamList.add(TEAM_TP);
             teamList.add(TEAM_DJ);

--- a/src/main/java/SeoulMilk1_BE/user/repository/init/TeamInitializer.java
+++ b/src/main/java/SeoulMilk1_BE/user/repository/init/TeamInitializer.java
@@ -28,11 +28,11 @@ public class TeamInitializer implements ApplicationRunner {
             List<Team> teamList = new ArrayList<>();
 
             Team TEAM_ADMIN = Team.builder()
-                    .name("서울우유협동조합")
+                    .name("관리자")
                     .build();
 
             Team TEAM_HQ = Team.builder()
-                    .name("서울우유협동조합")
+                    .name("경영총괄팀")
                     .build();
 
             Team TEAM_CS = Team.builder()

--- a/src/main/java/SeoulMilk1_BE/user/repository/init/UserInitializer.java
+++ b/src/main/java/SeoulMilk1_BE/user/repository/init/UserInitializer.java
@@ -34,10 +34,6 @@ public class UserInitializer implements ApplicationRunner {
         if (userRepository.count() > 0) {
             log.info("[User] 더미 데이터 존재");
         } else {
-            Team adminTeam = teamRepository.findById(1L)
-                    .orElseThrow(() -> new TeamNotFoundException(TEAM_NOT_FOUND));
-            Team hqTeam = teamRepository.findById(2L)
-                    .orElseThrow(() -> new TeamNotFoundException(TEAM_NOT_FOUND));
             Team csTeam = teamRepository.findById(3L)
                     .orElseThrow(() -> new TeamNotFoundException(TEAM_NOT_FOUND));
 
@@ -52,7 +48,6 @@ public class UserInitializer implements ApplicationRunner {
                     .profileImageUrl("image.png")
                     .isAssigned(true)
                     .role(ADMIN)
-                    .team(adminTeam)
                     .build();
 
             User DUMMY_USER1 = User.builder()
@@ -64,7 +59,6 @@ public class UserInitializer implements ApplicationRunner {
                     .profileImageUrl("image.png")
                     .isAssigned(true)
                     .role(HQ_USER)
-                    .team(hqTeam)
                     .build();
 
             User DUMMY_USER2 = User.builder()

--- a/src/main/java/SeoulMilk1_BE/user/repository/init/UserInitializer.java
+++ b/src/main/java/SeoulMilk1_BE/user/repository/init/UserInitializer.java
@@ -34,7 +34,13 @@ public class UserInitializer implements ApplicationRunner {
         if (userRepository.count() > 0) {
             log.info("[User] 더미 데이터 존재");
         } else {
-            Team csTeam = teamRepository.findById(1L)
+            Team TEAM1 = teamRepository.findById(1L)
+                    .orElseThrow(() -> new TeamNotFoundException(TEAM_NOT_FOUND));
+            Team TEAM2 = teamRepository.findById(2L)
+                    .orElseThrow(() -> new TeamNotFoundException(TEAM_NOT_FOUND));
+            Team TEAM3 = teamRepository.findById(3L)
+                    .orElseThrow(() -> new TeamNotFoundException(TEAM_NOT_FOUND));
+            Team TEAM4 = teamRepository.findById(4L)
                     .orElseThrow(() -> new TeamNotFoundException(TEAM_NOT_FOUND));
 
             List<User> userList = new ArrayList<>();
@@ -70,12 +76,75 @@ public class UserInitializer implements ApplicationRunner {
                     .profileImageUrl("image.png")
                     .isAssigned(true)
                     .role(CS_USER)
-                    .team(csTeam)
+                    .team(TEAM1)
+                    .build();
+
+            User DUMMY_UNASSIGNED_USER1 = User.builder()
+                    .employeeId(100001L)
+                    .password(passwordEncoder.encode("password"))
+                    .name("박지민")
+                    .email("park.jimin@naver.com")
+                    .phone("01011112233")
+                    .profileImageUrl("image.png")
+                    .isAssigned(false)
+                    .role(HQ_USER)
+                    .build();
+
+            User DUMMY_UNASSIGNED_USER2 = User.builder()
+                    .employeeId(100002L)
+                    .password(passwordEncoder.encode("password"))
+                    .name("이수진")
+                    .email("lee.sujin@naver.com")
+                    .phone("01022223344")
+                    .profileImageUrl("image.png")
+                    .isAssigned(false)
+                    .role(CS_USER)
+                    .team(TEAM2)
+                    .build();
+
+            User DUMMY_UNASSIGNED_USER3 = User.builder()
+                    .employeeId(100003L)
+                    .password(passwordEncoder.encode("password"))
+                    .name("정우성")
+                    .email("jung.woosung@naver.com")
+                    .phone("01033334455")
+                    .profileImageUrl("image.png")
+                    .isAssigned(false)
+                    .role(HQ_USER)
+                    .build();
+
+            User DUMMY_UNASSIGNED_USER4 = User.builder()
+                    .employeeId(100004L)
+                    .password(passwordEncoder.encode("password"))
+                    .name("최영수")
+                    .email("choi.youngsoo@naver.com")
+                    .phone("01044445566")
+                    .profileImageUrl("image.png")
+                    .isAssigned(false)
+                    .role(CS_USER)
+                    .team(TEAM3)
+                    .build();
+
+            User DUMMY_UNASSIGNED_USER5 = User.builder()
+                    .employeeId(100005L)
+                    .password(passwordEncoder.encode("password"))
+                    .name("김하늘")
+                    .email("kim.hanul@naver.com")
+                    .phone("01055556677")
+                    .profileImageUrl("image.png")
+                    .isAssigned(false)
+                    .role(CS_USER)
+                    .team(TEAM4)
                     .build();
 
             userList.add(DUMMY_ADMIN);
             userList.add(DUMMY_USER1);
             userList.add(DUMMY_USER2);
+            userList.add(DUMMY_UNASSIGNED_USER1);
+            userList.add(DUMMY_UNASSIGNED_USER2);
+            userList.add(DUMMY_UNASSIGNED_USER3);
+            userList.add(DUMMY_UNASSIGNED_USER4);
+            userList.add(DUMMY_UNASSIGNED_USER5);
 
             userRepository.saveAll(userList);
         }

--- a/src/main/java/SeoulMilk1_BE/user/repository/init/UserInitializer.java
+++ b/src/main/java/SeoulMilk1_BE/user/repository/init/UserInitializer.java
@@ -34,7 +34,7 @@ public class UserInitializer implements ApplicationRunner {
         if (userRepository.count() > 0) {
             log.info("[User] 더미 데이터 존재");
         } else {
-            Team csTeam = teamRepository.findById(3L)
+            Team csTeam = teamRepository.findById(1L)
                     .orElseThrow(() -> new TeamNotFoundException(TEAM_NOT_FOUND));
 
             List<User> userList = new ArrayList<>();

--- a/src/main/java/SeoulMilk1_BE/user/service/AdminService.java
+++ b/src/main/java/SeoulMilk1_BE/user/service/AdminService.java
@@ -3,6 +3,8 @@ package SeoulMilk1_BE.user.service;
 import SeoulMilk1_BE.user.domain.User;
 import SeoulMilk1_BE.user.dto.response.PendingUserResponse;
 import SeoulMilk1_BE.user.dto.response.PendingUserResponseList;
+import SeoulMilk1_BE.user.dto.response.UserManageResponse;
+import SeoulMilk1_BE.user.dto.response.UserManageResponseList;
 import SeoulMilk1_BE.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -34,6 +36,18 @@ public class AdminService {
                 .toList();
 
         return PendingUserResponseList.of(userPage, responseList);
+    }
+
+    public UserManageResponseList findAllUsers(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+
+        Page<User> userPage = userRepository.findAll(pageable);
+
+        List<UserManageResponse> responseList = userPage.stream()
+                .map(UserManageResponse::from)
+                .toList();
+
+        return UserManageResponseList.of(userPage, responseList);
     }
 
     @Transactional

--- a/src/main/java/SeoulMilk1_BE/user/service/CsService.java
+++ b/src/main/java/SeoulMilk1_BE/user/service/CsService.java
@@ -1,0 +1,46 @@
+package SeoulMilk1_BE.user.service;
+
+import SeoulMilk1_BE.nts_tax.dto.response.CsSearchTaxResponse;
+import SeoulMilk1_BE.nts_tax.dto.response.CsSearchTaxResponseList;
+import SeoulMilk1_BE.nts_tax.repository.NtsTaxRepositoryCustom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CsService {
+
+    private final NtsTaxRepositoryCustom ntsTaxRepositoryCustom;
+
+    public CsSearchTaxResponseList searchTax(Long userId, int page, int size, String startDate, String endDate, Long months) {
+        String start = formatInputData(startDate);
+        String end = formatInputData(endDate);
+
+        Pageable pageable = PageRequest.of(page, size);
+        Page<CsSearchTaxResponse> hqTaxResponsePage = ntsTaxRepositoryCustom.findTaxUsedInCS(pageable, userId, start, end, months);
+
+        List<CsSearchTaxResponse> responseList = hqTaxResponsePage.getContent();
+
+        return CsSearchTaxResponseList.from(responseList);
+    }
+
+    private static String formatInputData(String inputData) {
+        if (!StringUtils.hasText(inputData) || inputData.isEmpty()) {
+            return "";
+        }
+
+        return inputData.replace("-", "")
+                .replace("/", "")
+                .replace(" ", "")
+                .replace("\n", "")
+                .replace(".", "");
+    }
+}

--- a/src/main/java/SeoulMilk1_BE/user/service/CsService.java
+++ b/src/main/java/SeoulMilk1_BE/user/service/CsService.java
@@ -1,5 +1,6 @@
 package SeoulMilk1_BE.user.service;
 
+import SeoulMilk1_BE.nts_tax.domain.type.Status;
 import SeoulMilk1_BE.nts_tax.dto.response.CsSearchTaxResponse;
 import SeoulMilk1_BE.nts_tax.dto.response.CsSearchTaxResponseList;
 import SeoulMilk1_BE.nts_tax.repository.NtsTaxRepositoryCustom;
@@ -20,12 +21,12 @@ public class CsService {
 
     private final NtsTaxRepositoryCustom ntsTaxRepositoryCustom;
 
-    public CsSearchTaxResponseList searchTax(Long userId, int page, int size, String startDate, String endDate, Long months) {
+    public CsSearchTaxResponseList searchTax(Long userId, int page, int size, String startDate, String endDate, Long months, Status status) {
         String start = formatInputData(startDate);
         String end = formatInputData(endDate);
 
         Pageable pageable = PageRequest.of(page, size);
-        Page<CsSearchTaxResponse> hqTaxResponsePage = ntsTaxRepositoryCustom.findTaxUsedInCS(pageable, userId, start, end, months);
+        Page<CsSearchTaxResponse> hqTaxResponsePage = ntsTaxRepositoryCustom.findTaxUsedInCS(pageable, userId, start, end, months, status);
 
         List<CsSearchTaxResponse> responseList = hqTaxResponsePage.getContent();
 

--- a/src/main/java/SeoulMilk1_BE/user/service/CsService.java
+++ b/src/main/java/SeoulMilk1_BE/user/service/CsService.java
@@ -3,7 +3,7 @@ package SeoulMilk1_BE.user.service;
 import SeoulMilk1_BE.nts_tax.domain.type.Status;
 import SeoulMilk1_BE.nts_tax.dto.response.CsSearchTaxResponse;
 import SeoulMilk1_BE.nts_tax.dto.response.CsSearchTaxResponseList;
-import SeoulMilk1_BE.nts_tax.repository.NtsTaxRepositoryCustom;
+import SeoulMilk1_BE.nts_tax.repository.NtsTaxRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -19,14 +19,14 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class CsService {
 
-    private final NtsTaxRepositoryCustom ntsTaxRepositoryCustom;
+    private final NtsTaxRepository ntsTaxRepository;
 
     public CsSearchTaxResponseList searchTax(Long userId, int page, int size, String startDate, String endDate, Long months, Status status) {
         String start = formatInputData(startDate);
         String end = formatInputData(endDate);
 
         Pageable pageable = PageRequest.of(page, size);
-        Page<CsSearchTaxResponse> hqTaxResponsePage = ntsTaxRepositoryCustom.findTaxUsedInCS(pageable, userId, start, end, months, status);
+        Page<CsSearchTaxResponse> hqTaxResponsePage = ntsTaxRepository.findTaxUsedInCS(pageable, userId, start, end, months, status);
 
         List<CsSearchTaxResponse> responseList = hqTaxResponsePage.getContent();
 

--- a/src/main/java/SeoulMilk1_BE/user/service/CsService.java
+++ b/src/main/java/SeoulMilk1_BE/user/service/CsService.java
@@ -26,11 +26,13 @@ public class CsService {
         String end = formatInputData(endDate);
 
         Pageable pageable = PageRequest.of(page, size);
-        Page<CsSearchTaxResponse> hqTaxResponsePage = ntsTaxRepository.findTaxUsedInCS(pageable, userId, start, end, months, status);
+        Page<CsSearchTaxResponse> csTaxResponsePage = ntsTaxRepository.findTaxUsedInCS(pageable, userId, start, end, months, status);
 
-        List<CsSearchTaxResponse> responseList = hqTaxResponsePage.getContent();
+        Long totalElements = csTaxResponsePage.getTotalElements();
+        Integer totalPages = csTaxResponsePage.getTotalPages();
+        List<CsSearchTaxResponse> responseList = csTaxResponsePage.getContent();
 
-        return CsSearchTaxResponseList.from(responseList);
+        return CsSearchTaxResponseList.of(totalElements, totalPages, responseList);
     }
 
     private static String formatInputData(String inputData) {

--- a/src/main/java/SeoulMilk1_BE/user/service/HqService.java
+++ b/src/main/java/SeoulMilk1_BE/user/service/HqService.java
@@ -52,9 +52,11 @@ public class HqService {
         Pageable pageable = PageRequest.of(page, size);
         Page<HqSearchTaxResponse> hqTaxResponsePage = ntsTaxRepository.findTaxUsedInHQ(pageable, keyword, start, end, months, status);
 
+        Long totalElements = hqTaxResponsePage.getTotalElements();
+        Integer totalPages = hqTaxResponsePage.getTotalPages();
         List<HqSearchTaxResponse> responseList = hqTaxResponsePage.getContent();
 
-        return HqSearchTaxResponseList.from(responseList);
+        return HqSearchTaxResponseList.of(totalElements, totalPages, responseList);
     }
 
     public HqSearchCsNameResponseList searchCsName(String keyword) {

--- a/src/main/java/SeoulMilk1_BE/user/service/HqService.java
+++ b/src/main/java/SeoulMilk1_BE/user/service/HqService.java
@@ -7,7 +7,6 @@ import SeoulMilk1_BE.nts_tax.dto.response.HqSearchTaxResponseList;
 import SeoulMilk1_BE.nts_tax.dto.response.HqTaxResponse;
 import SeoulMilk1_BE.nts_tax.dto.response.HqTaxResponseList;
 import SeoulMilk1_BE.nts_tax.repository.NtsTaxRepository;
-import SeoulMilk1_BE.nts_tax.repository.NtsTaxRepositoryCustom;
 import SeoulMilk1_BE.user.dto.response.HqSearchCsNameResponse;
 import SeoulMilk1_BE.user.dto.response.HqSearchCsNameResponseList;
 import SeoulMilk1_BE.user.dto.response.HqSearchCsResponse;
@@ -31,7 +30,6 @@ import java.util.List;
 public class HqService {
 
     private final NtsTaxRepository ntsTaxRepository;
-    private final NtsTaxRepositoryCustom ntsTaxRepositoryCustom;
     private final TeamRepository teamRepository;
 
     public HqTaxResponseList getTaxInfo(int page, int size) {
@@ -52,7 +50,7 @@ public class HqService {
         String end = formatInputData(endDate);
 
         Pageable pageable = PageRequest.of(page, size);
-        Page<HqSearchTaxResponse> hqTaxResponsePage = ntsTaxRepositoryCustom.findTaxUsedInHQ(pageable, keyword, start, end, months, status);
+        Page<HqSearchTaxResponse> hqTaxResponsePage = ntsTaxRepository.findTaxUsedInHQ(pageable, keyword, start, end, months, status);
 
         List<HqSearchTaxResponse> responseList = hqTaxResponsePage.getContent();
 

--- a/src/main/java/SeoulMilk1_BE/user/service/HqService.java
+++ b/src/main/java/SeoulMilk1_BE/user/service/HqService.java
@@ -1,6 +1,8 @@
 package SeoulMilk1_BE.user.service;
 
 import SeoulMilk1_BE.nts_tax.domain.NtsTax;
+import SeoulMilk1_BE.nts_tax.dto.response.HqSearchTaxResponse;
+import SeoulMilk1_BE.nts_tax.dto.response.HqSearchTaxResponseList;
 import SeoulMilk1_BE.nts_tax.dto.response.HqTaxResponse;
 import SeoulMilk1_BE.nts_tax.dto.response.HqTaxResponseList;
 import SeoulMilk1_BE.nts_tax.repository.NtsTaxRepository;
@@ -44,16 +46,16 @@ public class HqService {
         return HqTaxResponseList.from(responseList);
     }
 
-    public HqTaxResponseList searchTax(int page, int size, String keyword, String startDate, String endDate, Long months) {
+    public HqSearchTaxResponseList searchTax(int page, int size, String keyword, String startDate, String endDate, Long months) {
         String start = formatInputData(startDate);
         String end = formatInputData(endDate);
 
         Pageable pageable = PageRequest.of(page, size);
-        Page<HqTaxResponse> hqTaxResponsePage = ntsTaxRepositoryCustom.findTax(pageable, keyword, start, end, months);
+        Page<HqSearchTaxResponse> hqTaxResponsePage = ntsTaxRepositoryCustom.findTaxUsedInHQ(pageable, keyword, start, end, months);
 
-        List<HqTaxResponse> responseList = hqTaxResponsePage.getContent();
+        List<HqSearchTaxResponse> responseList = hqTaxResponsePage.getContent();
 
-        return HqTaxResponseList.from(responseList);
+        return HqSearchTaxResponseList.from(responseList);
     }
 
     public HqSearchCsNameResponseList searchCsName(String keyword) {

--- a/src/main/java/SeoulMilk1_BE/user/service/HqService.java
+++ b/src/main/java/SeoulMilk1_BE/user/service/HqService.java
@@ -1,6 +1,7 @@
 package SeoulMilk1_BE.user.service;
 
 import SeoulMilk1_BE.nts_tax.domain.NtsTax;
+import SeoulMilk1_BE.nts_tax.domain.type.Status;
 import SeoulMilk1_BE.nts_tax.dto.response.HqSearchTaxResponse;
 import SeoulMilk1_BE.nts_tax.dto.response.HqSearchTaxResponseList;
 import SeoulMilk1_BE.nts_tax.dto.response.HqTaxResponse;
@@ -46,12 +47,12 @@ public class HqService {
         return HqTaxResponseList.from(responseList);
     }
 
-    public HqSearchTaxResponseList searchTax(int page, int size, String keyword, String startDate, String endDate, Long months) {
+    public HqSearchTaxResponseList searchTax(int page, int size, String keyword, String startDate, String endDate, Long months, Status status) {
         String start = formatInputData(startDate);
         String end = formatInputData(endDate);
 
         Pageable pageable = PageRequest.of(page, size);
-        Page<HqSearchTaxResponse> hqTaxResponsePage = ntsTaxRepositoryCustom.findTaxUsedInHQ(pageable, keyword, start, end, months);
+        Page<HqSearchTaxResponse> hqTaxResponsePage = ntsTaxRepositoryCustom.findTaxUsedInHQ(pageable, keyword, start, end, months, status);
 
         List<HqSearchTaxResponse> responseList = hqTaxResponsePage.getContent();
 

--- a/src/main/java/SeoulMilk1_BE/user/service/UserService.java
+++ b/src/main/java/SeoulMilk1_BE/user/service/UserService.java
@@ -1,6 +1,8 @@
 package SeoulMilk1_BE.user.service;
 
+import SeoulMilk1_BE.user.domain.Team;
 import SeoulMilk1_BE.user.domain.User;
+import SeoulMilk1_BE.user.dto.request.UpdateUserRequest;
 import SeoulMilk1_BE.user.dto.response.UserDetailResponse;
 import SeoulMilk1_BE.user.dto.response.UserResponse;
 import SeoulMilk1_BE.user.exception.UserNotFoundException;
@@ -10,6 +12,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import static SeoulMilk1_BE.global.apiPayload.code.status.ErrorStatus.USER_NOT_FOUND;
+import static SeoulMilk1_BE.user.domain.type.Role.CS_USER;
+import static SeoulMilk1_BE.user.util.UserConstants.UPDATE_SUCCESS;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +30,19 @@ public class UserService {
     public UserDetailResponse getUserDetail(Long userId) {
         User user = findUser(userId);
         return UserDetailResponse.from(user);
+    }
+
+    @Transactional
+    public String updateUser(Long userId, UpdateUserRequest request) {
+        User user = findUser(userId);
+        user.updateUser(request);
+
+        if (user.getRole() == CS_USER) {
+            Team team = user.getTeam();
+            team.updateTeam(request);
+        }
+
+        return UPDATE_SUCCESS.getMessage();
     }
 
     public User findUser(Long userId) {

--- a/src/main/java/SeoulMilk1_BE/user/service/UserService.java
+++ b/src/main/java/SeoulMilk1_BE/user/service/UserService.java
@@ -1,6 +1,7 @@
 package SeoulMilk1_BE.user.service;
 
 import SeoulMilk1_BE.user.domain.User;
+import SeoulMilk1_BE.user.dto.response.UserDetailResponse;
 import SeoulMilk1_BE.user.dto.response.UserResponse;
 import SeoulMilk1_BE.user.exception.UserNotFoundException;
 import SeoulMilk1_BE.user.repository.UserRepository;
@@ -20,6 +21,11 @@ public class UserService {
     public UserResponse getUserInfo(Long userId) {
         User user = findUser(userId);
         return UserResponse.from(user);
+    }
+
+    public UserDetailResponse getUserDetail(Long userId) {
+        User user = findUser(userId);
+        return UserDetailResponse.from(user);
     }
 
     public User findUser(Long userId) {

--- a/src/main/java/SeoulMilk1_BE/user/service/UserService.java
+++ b/src/main/java/SeoulMilk1_BE/user/service/UserService.java
@@ -39,7 +39,7 @@ public class UserService {
 
         if (user.getRole() == CS_USER) {
             Team team = user.getTeam();
-            team.updateTeam(request);
+            team.updateTeam(request.bank(), request.account());
         }
 
         return UPDATE_SUCCESS.getMessage();

--- a/src/main/java/SeoulMilk1_BE/user/util/UserConstants.java
+++ b/src/main/java/SeoulMilk1_BE/user/util/UserConstants.java
@@ -11,6 +11,7 @@ public enum UserConstants {
     DELETED("회원 삭제가 완료되었습니다."),
     DUPLICATE_EMPLOYEE_ID("이미 가입된 사번입니다."),
     VALID_EMPLOYEE_ID("가입 가능한 사번입니다."),
+    UPDATE_SUCCESS("내 정보 수정이 완료되었습니다."),
     ;
 
     private final String message;


### PR DESCRIPTION
## Issue

- #20 


## Summary

- 고객센터 -> 대리점으로 명명 변경하였습니다.
- 관리자와 본사는 Team을 현재는 사용하지 않도록 수정하였습니다.
- 회원가입에서 사용될 칼럼을 부분 수정하였습니다.
- 세금계산서 검색에 상태 필터를 추가하였습니다.
- 관리자 유저 관리 파트에 유저의 등록 여부 칼럼을 추가하였습니다.
- 본사 / 대리점 회원가입 분리하였습니다.
- 대리점 홈 화면 & 세금계산서 상태 변경 내용들은 추후 반영해서 수정하도록 하겠습니다!

## Describe your code
![image](https://github.com/user-attachments/assets/317e0506-840f-44b2-b574-2a8ba37677c4)
![image](https://github.com/user-attachments/assets/4a2f157c-12a7-46af-b572-deddde0fb860)

# Check
- [x] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
